### PR TITLE
refactor: remove cw-controllers and replace ownership control with cw_ownable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,6 @@ dependencies = [
  "anybuf",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-controllers",
  "cw-ownable",
  "cw-storage-plus",
  "test-case",
@@ -451,21 +450,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cw-controllers"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c1804013d21060b994dea28a080f9eab78a3bcb6b617f05e7634b0600bf7b1"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-storage-plus",
- "cw-utils",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "cw-migrate-error-derive"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,9 +675,9 @@ dependencies = [
  "amm",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-controllers",
  "cw-migrate-error-derive",
  "cw-multi-test",
+ "cw-ownable",
  "cw-storage-plus",
  "cw-utils",
  "cw2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ cw-multi-test = { version = "2.1.1", features = [
 ] }
 uint = { version = "0.10.0" }
 anyhow = { version = "1.0.71" }
-cw-controllers = { version = "2.0.0" }
 cw-ownable = { version = "2.0.0" }
 anybuf = { version = "0.5.0" }
 sha2 = { version = "=0.10.8" }

--- a/contracts/epoch-manager/Cargo.toml
+++ b/contracts/epoch-manager/Cargo.toml
@@ -32,7 +32,7 @@ semver.workspace = true
 thiserror.workspace = true
 amm.workspace = true
 mantra-utils.workspace = true
-cw-controllers.workspace = true
+cw-ownable.workspace = true
 cw-utils.workspace = true
 cw-migrate-error-derive.workspace = true
 

--- a/contracts/epoch-manager/src/commands.rs
+++ b/contracts/epoch-manager/src/commands.rs
@@ -2,22 +2,16 @@ use cosmwasm_std::{DepsMut, MessageInfo, Response};
 
 use amm::epoch_manager::EpochConfig;
 
-use crate::state::{ADMIN, CONFIG};
+use crate::state::CONFIG;
 use crate::ContractError;
 
 /// Updates the config of the contract.
 pub fn update_config(
-    mut deps: DepsMut,
+    deps: DepsMut,
     info: &MessageInfo,
-    owner: Option<String>,
     epoch_config: Option<EpochConfig>,
 ) -> Result<Response, ContractError> {
-    ADMIN.assert_admin(deps.as_ref(), &info.sender)?;
-
-    if let Some(owner) = owner.clone() {
-        let new_admin = deps.api.addr_validate(owner.as_str())?;
-        ADMIN.set(deps.branch(), Some(new_admin))?;
-    }
+    cw_ownable::assert_owner(deps.storage, &info.sender)?;
 
     let mut config = CONFIG.load(deps.storage)?;
 
@@ -28,7 +22,6 @@ pub fn update_config(
 
     Ok(Response::default().add_attributes(vec![
         ("action", "update_config".to_string()),
-        ("owner", owner.unwrap_or_else(|| info.sender.to_string())),
         (
             "epoch_config",
             epoch_config.unwrap_or(config.epoch_config).to_string(),

--- a/contracts/epoch-manager/src/error.rs
+++ b/contracts/epoch-manager/src/error.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::StdError;
-use cw_controllers::{AdminError, HookError};
 use cw_migrate_error_derive::cw_migrate_invalid_version_error;
+use cw_ownable::OwnershipError;
 use cw_utils::PaymentError;
 use thiserror::Error;
 
@@ -11,10 +11,7 @@ pub enum ContractError {
     Std(#[from] StdError),
 
     #[error("{0}")]
-    AdminError(#[from] AdminError),
-
-    #[error("{0}")]
-    HookError(#[from] HookError),
+    OwnershipError(#[from] OwnershipError),
 
     #[error("The epoch id has overflowed.")]
     EpochOverflow,

--- a/contracts/epoch-manager/src/queries.rs
+++ b/contracts/epoch-manager/src/queries.rs
@@ -1,18 +1,12 @@
-use cosmwasm_std::{ensure, Addr, Deps, Env, StdError, StdResult, Timestamp, Uint64};
+use cosmwasm_std::{ensure, Deps, Env, StdError, StdResult, Timestamp, Uint64};
 
 use amm::epoch_manager::{ConfigResponse, Epoch, EpochResponse};
 
-use crate::state::{ADMIN, CONFIG};
+use crate::state::CONFIG;
 
 /// Queries the config. Returns a [ConfigResponse].
 pub(crate) fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
-    let admin = ADMIN.get(deps)?.unwrap_or(Addr::unchecked(""));
-    let config = CONFIG.load(deps.storage)?;
-
-    Ok(ConfigResponse {
-        owner: admin,
-        epoch_config: config.epoch_config,
-    })
+    CONFIG.load(deps.storage)
 }
 
 /// Derives the current epoch. Returns an [EpochResponse].

--- a/contracts/epoch-manager/src/state.rs
+++ b/contracts/epoch-manager/src/state.rs
@@ -1,6 +1,4 @@
 use amm::epoch_manager::Config;
-use cw_controllers::Admin;
 use cw_storage_plus::Item;
 
 pub const CONFIG: Item<Config> = Item::new("config");
-pub const ADMIN: Admin = Admin::new("admin");

--- a/contracts/epoch-manager/tests/common.rs
+++ b/contracts/epoch-manager/tests/common.rs
@@ -1,5 +1,6 @@
 use cosmwasm_std::testing::mock_env;
 use cosmwasm_std::{DepsMut, Env, MessageInfo, Response, Uint64};
+use cw_multi_test::IntoBech32;
 
 use amm::epoch_manager::{EpochConfig, InstantiateMsg};
 use epoch_manager::contract::instantiate;
@@ -14,6 +15,7 @@ pub fn mock_instantiation(
 ) -> Result<Response, ContractError> {
     let current_time = env.block.time;
     let msg = InstantiateMsg {
+        owner: "owner".into_bech32().to_string(),
         epoch_config: EpochConfig {
             duration: Uint64::new(86400),
             genesis_epoch: Uint64::new(current_time.nanos()),

--- a/contracts/epoch-manager/tests/epoch.rs
+++ b/contracts/epoch-manager/tests/epoch.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env};
-use cosmwasm_std::{from_json, Timestamp, Uint128, Uint64};
+use cosmwasm_std::{from_json, Timestamp, Uint64};
 use cw_multi_test::IntoBech32;
 
 use amm::epoch_manager::{
@@ -119,6 +119,7 @@ fn get_new_epoch_unsuccessfully() {
 
     let current_time = env.block.time;
     let msg = InstantiateMsg {
+        owner: "owner".into_bech32().to_string(),
         epoch_config: EpochConfig {
             duration: Uint64::new(86400),
             // instantiate the epoch manager with the genesis epoch 1 day in the future

--- a/contracts/epoch-manager/tests/instantiate.rs
+++ b/contracts/epoch-manager/tests/instantiate.rs
@@ -16,6 +16,7 @@ fn instantiation_successful() {
     let owner = "owner".into_bech32();
     let info = message_info(&owner, &[]);
     let msg = InstantiateMsg {
+        owner: "owner".into_bech32().to_string(),
         epoch_config: EpochConfig {
             duration: Uint64::new(86400),
             genesis_epoch: Uint64::new(current_time.nanos()),
@@ -33,7 +34,6 @@ fn instantiation_successful() {
         },
         config_res.epoch_config
     );
-    assert_eq!(owner, config_res.owner);
 }
 
 #[test]
@@ -44,6 +44,7 @@ fn instantiation_unsuccessful() {
     let owner = "owner".into_bech32();
     let info = message_info(&owner, &[]);
     let msg = InstantiateMsg {
+        owner: "owner".into_bech32().to_string(),
         epoch_config: EpochConfig {
             duration: Uint64::new(86400),
             genesis_epoch: Uint64::new(current_time.minus_days(1).nanos()),

--- a/contracts/farm-manager/tests/common/suite.rs
+++ b/contracts/farm-manager/tests/common/suite.rs
@@ -132,16 +132,16 @@ impl TestingSuite {
     #[allow(clippy::inconsistent_digit_grouping)]
     fn create_epoch_manager(&mut self) {
         let epoch_manager_contract = self.app.store_code(epoch_manager_contract());
+        let creator = self.creator().clone();
 
         // create epoch manager
         let msg = amm::epoch_manager::InstantiateMsg {
+            owner: creator.to_string(),
             epoch_config: EpochConfig {
                 duration: Uint64::new(86400_000000000u64),
                 genesis_epoch: Uint64::new(1712242800_000000000u64), // April 4th 2024 15:00:00 UTC
             },
         };
-
-        let creator = self.creator().clone();
 
         self.epoch_manager_addr = self
             .app

--- a/contracts/pool-manager/src/tests/suite.rs
+++ b/contracts/pool-manager/src/tests/suite.rs
@@ -237,7 +237,10 @@ impl TestingSuite {
     fn create_epoch_manager(&mut self) {
         let epoch_manager_id = self.app.store_code(epoch_manager_contract());
 
+        let creator = self.creator().clone();
+
         let msg = amm::epoch_manager::InstantiateMsg {
+            owner: creator.to_string(),
             epoch_config: EpochConfig {
                 duration: Uint64::new(86_400_000000000),
                 genesis_epoch: Uint64::new(1714057200_000000000),

--- a/packages/amm/Cargo.toml
+++ b/packages/amm/Cargo.toml
@@ -13,7 +13,6 @@ authors.workspace = true
 cosmwasm-std.workspace = true
 cosmwasm-schema.workspace = true
 cw-ownable.workspace = true
-cw-controllers.workspace = true
 cw-storage-plus.workspace = true
 uint.workspace = true
 anybuf.workspace = true

--- a/packages/amm/src/epoch_manager.rs
+++ b/packages/amm/src/epoch_manager.rs
@@ -3,25 +3,28 @@ use std::fmt;
 use std::fmt::Display;
 
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Deps, StdResult, Timestamp, Uint64};
+use cosmwasm_std::{Deps, StdResult, Timestamp, Uint64};
+use cw_ownable::{cw_ownable_execute, cw_ownable_query};
 
 #[cw_serde]
 pub struct InstantiateMsg {
+    /// The owner of the contract.
+    pub owner: String,
     /// The configuration for the epochs.
     pub epoch_config: EpochConfig,
 }
 
+#[cw_ownable_execute]
 #[cw_serde]
 pub enum ExecuteMsg {
     /// Updates the contract configuration.
     UpdateConfig {
-        /// The new owner of the contract.
-        owner: Option<String>,
         /// The new epoch configuration.
         epoch_config: Option<EpochConfig>,
     },
 }
 
+#[cw_ownable_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
@@ -88,28 +91,12 @@ impl Display for EpochConfig {
     }
 }
 
+pub type ConfigResponse = Config;
+
 /// The contract configuration.
 #[cw_serde]
 pub struct Config {
     /// The epoch configuration
-    pub epoch_config: EpochConfig,
-}
-
-impl Config {
-    pub fn to_config_response(self, owner: Addr) -> ConfigResponse {
-        ConfigResponse {
-            owner,
-            epoch_config: self.epoch_config,
-        }
-    }
-}
-
-/// The response for the config query.
-#[cw_serde]
-pub struct ConfigResponse {
-    /// The owner of the contract.
-    pub owner: Addr,
-    /// The epoch configuration.
     pub epoch_config: EpochConfig,
 }
 


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

## Related Issues

Closes #16 , removes the cw-controllers crate and replaces the ownership management on epoch manager with cw_ownable as the hooks dependency was dropped. 

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/MANTRA-Finance/amm/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to MANTRA!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Finance/amm/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed with `just schemas`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced ownership management with the introduction of the `cw-ownable` dependency.
	- Added new query capabilities for ownership information in the contract.
	- Updated contract instantiation to include an owner field.

- **Bug Fixes**
	- Simplified logic in the `update_config` function by removing unnecessary parameters and assertions.

- **Documentation**
	- Improved clarity of documentation for `EpochConfig` struct.

- **Tests**
	- Updated test cases to reflect changes in ownership management and configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->