### PR TITLE
refactor: use seconds instead of nanos on epoch manager

### DIFF
--- a/.github/workflows/ci-test-lints.yaml
+++ b/.github/workflows/ci-test-lints.yaml
@@ -44,7 +44,7 @@ jobs:
           profile: minimal
           toolchain: 1.80.0
           override: true
-          components: rustfmt, clippy
+          components: rustfmt, clippy¸¸¸Ω
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "epoch-manager"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "amm",
  "cosmwasm-schema",

--- a/contracts/epoch-manager/Cargo.toml
+++ b/contracts/epoch-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "epoch-manager"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Kerber0x <kerber0x@protonmail.com>"]
 edition.workspace = true
 description = "The Epoch Manager contract keeps track of epochs."

--- a/contracts/epoch-manager/src/contract.rs
+++ b/contracts/epoch-manager/src/contract.rs
@@ -24,7 +24,7 @@ pub fn instantiate(
 
     // validate start_time for the initial epoch
     ensure!(
-        msg.epoch_config.genesis_epoch.u64() >= env.block.time.nanos(), //todo change to seconds
+        msg.epoch_config.genesis_epoch.u64() >= env.block.time.seconds(),
         ContractError::InvalidStartTime
     );
 

--- a/contracts/epoch-manager/src/queries.rs
+++ b/contracts/epoch-manager/src/queries.rs
@@ -14,15 +14,15 @@ pub(crate) fn query_current_epoch(deps: Deps, env: Env) -> StdResult<EpochRespon
     let config = CONFIG.load(deps.storage)?;
 
     ensure!(
-        env.block.time.nanos() >= config.epoch_config.genesis_epoch.u64(),
+        env.block.time.seconds() >= config.epoch_config.genesis_epoch.u64(),
         StdError::generic_err("Genesis epoch has not started")
     );
 
     let current_epoch = Uint64::new(
         env.block
             .time
-            .minus_nanos(config.epoch_config.genesis_epoch.u64())
-            .nanos(),
+            .minus_seconds(config.epoch_config.genesis_epoch.u64())
+            .seconds(),
     )
     .checked_div_floor((config.epoch_config.duration.u64(), 1u64))
     .map_err(|e| StdError::generic_err(format!("Error: {:?}", e)))?;
@@ -39,7 +39,7 @@ pub(crate) fn query_current_epoch(deps: Deps, env: Env) -> StdResult<EpochRespon
 
     let epoch = Epoch {
         id: current_epoch.u64(),
-        start_time: Timestamp::from_nanos(start_time.u64()),
+        start_time: Timestamp::from_seconds(start_time.u64()),
     };
 
     Ok(EpochResponse { epoch })
@@ -61,7 +61,7 @@ pub(crate) fn query_epoch(deps: Deps, id: u64) -> StdResult<EpochResponse> {
 
     let epoch = Epoch {
         id,
-        start_time: Timestamp::from_nanos(start_time.u64()),
+        start_time: Timestamp::from_seconds(start_time.u64()),
     };
 
     Ok(epoch.to_epoch_response())

--- a/contracts/epoch-manager/tests/common.rs
+++ b/contracts/epoch-manager/tests/common.rs
@@ -18,7 +18,7 @@ pub fn mock_instantiation(
         owner: "owner".into_bech32().to_string(),
         epoch_config: EpochConfig {
             duration: Uint64::new(86400),
-            genesis_epoch: Uint64::new(current_time.nanos()),
+            genesis_epoch: Uint64::new(current_time.seconds()),
         },
     };
 

--- a/contracts/epoch-manager/tests/config.rs
+++ b/contracts/epoch-manager/tests/config.rs
@@ -25,7 +25,7 @@ fn update_config_successfully() {
     assert_eq!(
         EpochConfig {
             duration: Uint64::new(86400),
-            genesis_epoch: Uint64::new(current_time.nanos()),
+            genesis_epoch: Uint64::new(current_time.seconds()),
         },
         config_res.epoch_config
     );
@@ -33,7 +33,7 @@ fn update_config_successfully() {
     let msg = ExecuteMsg::UpdateConfig {
         epoch_config: Some(EpochConfig {
             duration: Uint64::new(172800),
-            genesis_epoch: Uint64::new(current_time.nanos()),
+            genesis_epoch: Uint64::new(current_time.seconds()),
         }),
     };
 
@@ -44,7 +44,7 @@ fn update_config_successfully() {
     assert_eq!(
         EpochConfig {
             duration: Uint64::new(172800),
-            genesis_epoch: Uint64::new(current_time.nanos()),
+            genesis_epoch: Uint64::new(current_time.seconds()),
         },
         config_res.epoch_config
     );
@@ -65,7 +65,7 @@ fn update_config_unsuccessfully() {
     assert_eq!(
         EpochConfig {
             duration: Uint64::new(86400),
-            genesis_epoch: Uint64::new(current_time.nanos()),
+            genesis_epoch: Uint64::new(current_time.seconds()),
         },
         config_res.epoch_config
     );
@@ -73,7 +73,7 @@ fn update_config_unsuccessfully() {
     let msg = ExecuteMsg::UpdateConfig {
         epoch_config: Some(EpochConfig {
             duration: Uint64::new(172800),
-            genesis_epoch: Uint64::new(current_time.nanos()),
+            genesis_epoch: Uint64::new(current_time.seconds()),
         }),
     };
 
@@ -96,7 +96,7 @@ fn update_config_unsuccessfully() {
     assert_eq!(
         EpochConfig {
             duration: Uint64::new(86400),
-            genesis_epoch: Uint64::new(current_time.nanos()),
+            genesis_epoch: Uint64::new(current_time.seconds()),
         },
         config_res.epoch_config
     );

--- a/contracts/epoch-manager/tests/epoch.rs
+++ b/contracts/epoch-manager/tests/epoch.rs
@@ -30,14 +30,14 @@ fn get_new_epoch_successfully() {
         .unwrap();
 
     // move time ahead so we can get the new epoch
-    env.block.time = Timestamp::from_nanos(next_epoch_start_time.u64());
+    env.block.time = Timestamp::from_seconds(next_epoch_start_time.u64());
 
     let query_res = query(deps.as_ref(), env.clone(), QueryMsg::CurrentEpoch {}).unwrap();
     let epoch_response: EpochResponse = from_json(query_res).unwrap();
 
     let current_epoch = Epoch {
         id: 1,
-        start_time: Timestamp::from_nanos(next_epoch_start_time.u64()),
+        start_time: Timestamp::from_seconds(next_epoch_start_time.u64()),
     };
     assert_eq!(epoch_response.epoch, current_epoch);
 
@@ -52,8 +52,8 @@ fn get_new_epoch_successfully() {
         epoch_response.epoch,
         Epoch {
             id: 2,
-            start_time: Timestamp::from_nanos(next_epoch_start_time.u64())
-                .plus_nanos(config_response.epoch_config.duration.u64()),
+            start_time: Timestamp::from_seconds(next_epoch_start_time.u64())
+                .plus_seconds(config_response.epoch_config.duration.u64()),
         }
     );
 
@@ -61,11 +61,11 @@ fn get_new_epoch_successfully() {
     env.block.time = env
         .block
         .time
-        .plus_nanos(config_response.epoch_config.duration.u64());
+        .plus_seconds(config_response.epoch_config.duration.u64());
 
     let third_epoch_time = current_epoch
         .start_time
-        .plus_nanos(config_response.epoch_config.duration.u64() * 2);
+        .plus_seconds(config_response.epoch_config.duration.u64() * 2);
 
     env.block.time = third_epoch_time;
 
@@ -83,7 +83,7 @@ fn get_new_epoch_successfully() {
     env.block.time = env
         .block
         .time
-        .plus_nanos(config_response.epoch_config.duration.u64() - 1);
+        .plus_seconds(config_response.epoch_config.duration.u64() - 1);
 
     let query_res = query(deps.as_ref(), env.clone(), QueryMsg::CurrentEpoch {}).unwrap();
     let epoch_response: EpochResponse = from_json(query_res).unwrap();
@@ -93,10 +93,10 @@ fn get_new_epoch_successfully() {
     // move time ahead but not enough to trigger the next epoch
     let fourth_epoch_time = current_epoch
         .start_time
-        .plus_nanos(config_response.epoch_config.duration.u64());
+        .plus_seconds(config_response.epoch_config.duration.u64());
 
     // move the time necessary to trigger next epoch
-    env.block.time = env.block.time.plus_nanos(1);
+    env.block.time = env.block.time.plus_seconds(1);
 
     let query_res = query(deps.as_ref(), env.clone(), QueryMsg::CurrentEpoch {}).unwrap();
     let epoch_response: EpochResponse = from_json(query_res).unwrap();
@@ -123,7 +123,7 @@ fn get_new_epoch_unsuccessfully() {
         epoch_config: EpochConfig {
             duration: Uint64::new(86400),
             // instantiate the epoch manager with the genesis epoch 1 day in the future
-            genesis_epoch: Uint64::new(current_time.plus_days(1).nanos()),
+            genesis_epoch: Uint64::new(current_time.plus_days(1).seconds()),
         },
     };
 
@@ -133,7 +133,7 @@ fn get_new_epoch_unsuccessfully() {
     let config_response: ConfigResponse = from_json(config_res).unwrap();
 
     // move time ahead but not enough to get above the genesis epoch a new epoch
-    env.block.time = Timestamp::from_nanos(
+    env.block.time = Timestamp::from_seconds(
         config_response
             .epoch_config
             .genesis_epoch
@@ -148,7 +148,7 @@ fn get_new_epoch_unsuccessfully() {
         .contains("Genesis epoch has not started"));
 
     // move time a bit ahead of the genesis epoch
-    env.block.time = env.block.time.plus_nanos(100);
+    env.block.time = env.block.time.plus_seconds(100);
 
     let query_res = query(deps.as_ref(), env.clone(), QueryMsg::CurrentEpoch {}).unwrap();
     let epoch_response: EpochResponse = from_json(query_res).unwrap();
@@ -157,7 +157,7 @@ fn get_new_epoch_unsuccessfully() {
         epoch_response.epoch,
         Epoch {
             id: 0,
-            start_time: Timestamp::from_nanos(config_response.epoch_config.genesis_epoch.u64()),
+            start_time: Timestamp::from_seconds(config_response.epoch_config.genesis_epoch.u64()),
         }
     );
 }

--- a/contracts/epoch-manager/tests/instantiate.rs
+++ b/contracts/epoch-manager/tests/instantiate.rs
@@ -18,8 +18,8 @@ fn instantiation_successful() {
     let msg = InstantiateMsg {
         owner: "owner".into_bech32().to_string(),
         epoch_config: EpochConfig {
-            duration: Uint64::new(86400),
-            genesis_epoch: Uint64::new(current_time.nanos()),
+            duration: Uint64::new(86_400),
+            genesis_epoch: Uint64::new(current_time.seconds()),
         },
     };
 
@@ -29,8 +29,8 @@ fn instantiation_successful() {
     let config_res: ConfigResponse = from_json(query_res).unwrap();
     assert_eq!(
         EpochConfig {
-            duration: Uint64::new(86400),
-            genesis_epoch: Uint64::new(current_time.nanos()),
+            duration: Uint64::new(86_400),
+            genesis_epoch: Uint64::new(current_time.seconds()),
         },
         config_res.epoch_config
     );
@@ -46,8 +46,8 @@ fn instantiation_unsuccessful() {
     let msg = InstantiateMsg {
         owner: "owner".into_bech32().to_string(),
         epoch_config: EpochConfig {
-            duration: Uint64::new(86400),
-            genesis_epoch: Uint64::new(current_time.minus_days(1).nanos()),
+            duration: Uint64::new(86_400),
+            genesis_epoch: Uint64::new(current_time.minus_days(1).seconds()),
         },
     };
 

--- a/contracts/farm-manager/tests/common/suite.rs
+++ b/contracts/farm-manager/tests/common/suite.rs
@@ -107,7 +107,7 @@ impl TestingSuite {
         self.create_fee_collector();
 
         // April 4th 2024 15:00:00 UTC
-        let timestamp = Timestamp::from_seconds(1712242800u64);
+        let timestamp = Timestamp::from_seconds(1_712_242_800u64);
         self.set_time(timestamp);
 
         // instantiates the farm manager contract
@@ -138,8 +138,8 @@ impl TestingSuite {
         let msg = amm::epoch_manager::InstantiateMsg {
             owner: creator.to_string(),
             epoch_config: EpochConfig {
-                duration: Uint64::new(86400_000000000u64),
-                genesis_epoch: Uint64::new(1712242800_000000000u64), // April 4th 2024 15:00:00 UTC
+                duration: Uint64::new(86_400u64),
+                genesis_epoch: Uint64::new(1_712_242_800u64), // April 4th 2024 15:00:00 UTC
             },
         };
 

--- a/contracts/pool-manager/src/tests/suite.rs
+++ b/contracts/pool-manager/src/tests/suite.rs
@@ -197,7 +197,7 @@ impl TestingSuite {
         self.create_farm_manager();
 
         // 25 April 2024 15:00:00 UTC
-        let timestamp = Timestamp::from_seconds(1714057200);
+        let timestamp = Timestamp::from_seconds(1_714_057_200);
         self.set_time(timestamp);
 
         let creator = self.creator().clone();
@@ -242,8 +242,8 @@ impl TestingSuite {
         let msg = amm::epoch_manager::InstantiateMsg {
             owner: creator.to_string(),
             epoch_config: EpochConfig {
-                duration: Uint64::new(86_400_000000000),
-                genesis_epoch: Uint64::new(1714057200_000000000),
+                duration: Uint64::new(86_400),
+                genesis_epoch: Uint64::new(1_714_057_200),
             },
         };
 

--- a/packages/amm/src/epoch_manager.rs
+++ b/packages/amm/src/epoch_manager.rs
@@ -74,10 +74,9 @@ impl Display for Epoch {
 /// The epoch configuration.
 #[cw_serde]
 pub struct EpochConfig {
-    //todo change to seconds
-    /// The duration of an epoch in nanoseconds.
+    /// The duration of an epoch in seconds.
     pub duration: Uint64,
-    /// Timestamp for the first epoch, in nanoseconds.
+    /// Timestamp for the first epoch, in seconds.
     pub genesis_epoch: Uint64,
 }
 


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

This PR simplifies the usage of nanoseconds for seconds on the epoch manager.

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/MANTRA-Finance/amm/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to MANTRA!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Finance/amm/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed with `just schemas`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the epoch management system to use seconds instead of nanoseconds for time calculations, enhancing clarity and consistency.
  
- **Bug Fixes**
	- Corrected time validation logic in the epoch manager to ensure accurate comparisons using seconds.

- **Documentation**
	- Updated comments in the `EpochConfig` struct to reflect the change in time measurement units from nanoseconds to seconds.

- **Tests**
	- Adjusted test cases to align with the new time representation, ensuring all epoch-related tests operate with seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->