### PR TITLE
fix(farm_manager): check position open state before expanding

### DIFF
--- a/contracts/farm-manager/src/position/commands.rs
+++ b/contracts/farm-manager/src/position/commands.rs
@@ -49,6 +49,14 @@ pub(crate) fn fill_position(
             ContractError::AssetMismatch
         );
 
+        // ensure the position is open
+        ensure!(
+            position.open,
+            ContractError::PositionAlreadyClosed {
+                identifier: position.identifier.clone()
+            }
+        );
+
         // if the position is found, ignore if there's a change in the unlocking_duration as it is
         // considered the same position, so use the existing unlocking_duration and only update the
         // amount of the LP asset


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

Fixes #21 . Checks the open state of a position before expanding it.

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/MANTRA-Finance/amm/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to MANTRA!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Finance/amm/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed with `just schemas`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced validation for position operations, ensuring actions are only performed on valid positions.
	- Added a new test to validate system behavior when attempting to refill a closed position.

- **Bug Fixes**
	- Implemented checks to prevent refilling or closing already closed positions, improving error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->