### PR TITLE
fix(farm_manager): avoid lp weight calculation being inflated when expanding a farm position

### DIFF
--- a/contracts/farm-manager/src/position/helpers.rs
+++ b/contracts/farm-manager/src/position/helpers.rs
@@ -87,7 +87,7 @@ fn return_latest_weight(
 
 /// Validates the `unlocking_duration` specified in the position params is within the range specified
 /// in the config.
-pub(crate) fn validate_unlocking_duration(
+pub(crate) fn validate_unlocking_duration_for_position(
     config: &Config,
     unlocking_duration: u64,
 ) -> Result<(), ContractError> {


### PR DESCRIPTION

## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

Fixes #27  by using the position's `unlocking_duration` when expanding a farm position. 

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/MANTRA-Finance/amm/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to MANTRA!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Finance/amm/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed with `just schemas`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of unlocking duration for positions, ensuring consistency for existing positions while allowing new positions to specify their unlocking duration.
	- Added a new test to verify that refilling a position does not affect the liquidity provider's weight, regardless of the unlocking duration used.

- **Bug Fixes**
	- Enhanced validation logic for unlocking duration to maintain clarity and consistency.

- **Tests**
	- Introduced a comprehensive test for the refill functionality related to unlocking periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->