### PR TITLE
fix(pool_manager): remove double counting deposit when lping into stable pool

### DIFF
--- a/contracts/pool-manager/src/helpers.rs
+++ b/contracts/pool-manager/src/helpers.rs
@@ -559,7 +559,6 @@ pub fn get_asset_indexes_in_pool(
     ))
 }
 
-// TODO: handle unwraps properly
 #[allow(clippy::unwrap_used)]
 pub fn compute_d(amp_factor: &u64, deposits: &[Coin]) -> Option<Uint512> {
     let n_coins = Uint128::from(deposits.len() as u128);
@@ -602,8 +601,6 @@ pub fn compute_d(amp_factor: &u64, deposits: &[Coin]) -> Option<Uint512> {
             }
         }
 
-        println!("D: {:?}", d);
-
         Some(d)
     }
 }
@@ -641,36 +638,26 @@ fn compute_next_d(
     Some(numerator.checked_div(denominator).unwrap())
 }
 
-/// Computes the amount of pool tokens to mint after a deposit.
+/// Computes the amount of lp tokens to mint after a deposit for a stableswap pool.
+/// Assumes the deposits have already been credited to the pool_assets.
 #[allow(clippy::unwrap_used, clippy::too_many_arguments)]
-pub fn compute_mint_amount_for_deposit(
+pub fn compute_mint_amount_for_stableswap_deposit(
     amp_factor: &u64,
     deposits: &[Coin],
-    swaps: &[Coin],
-    pool_token_supply: Uint128,
+    pool_assets: &[Coin],
+    pool_lp_token_total_supply: Uint128,
 ) -> Option<Uint128> {
     // Initial invariant
     let d_0 = compute_d(amp_factor, deposits)?;
 
-    let new_balances: Vec<Coin> = swaps
-        .iter()
-        .enumerate()
-        .map(|(i, pool_asset)| {
-            let deposit_amount = deposits[i].amount;
-            let new_amount = pool_asset.amount.checked_add(deposit_amount).unwrap();
-            Coin {
-                denom: pool_asset.denom.clone(),
-                amount: new_amount,
-            }
-        })
-        .collect();
-
     // Invariant after change
-    let d_1 = compute_d(amp_factor, &new_balances)?;
+    // notice that pool_assets already added the new deposits to the pool
+    let d_1 = compute_d(amp_factor, pool_assets)?;
+
     if d_1 <= d_0 {
         None
     } else {
-        let amount = Uint512::from(pool_token_supply)
+        let amount = Uint512::from(pool_lp_token_total_supply)
             .checked_mul(d_1.checked_sub(d_0).unwrap())
             .unwrap()
             .checked_div(d_0)
@@ -893,16 +880,20 @@ mod tests {
         ];
 
         let pool_assets = vec![
-            coin(MAX_TOKENS_IN.u128(), "denom1"),
-            coin(MAX_TOKENS_IN.u128(), "denom2"),
-            coin(MAX_TOKENS_IN.u128(), "denom4"),
+            coin(MAX_TOKENS_IN.u128() + MAX_TOKENS_IN.u128(), "denom1"),
+            coin(MAX_TOKENS_IN.u128() + MAX_TOKENS_IN.u128(), "denom2"),
+            coin(MAX_TOKENS_IN.u128() + MAX_TOKENS_IN.u128(), "denom4"),
         ];
 
         let pool_token_supply = MAX_TOKENS_IN;
 
-        let actual_mint_amount =
-            compute_mint_amount_for_deposit(&MIN_AMP, &deposits, &pool_assets, pool_token_supply)
-                .unwrap();
+        let actual_mint_amount = compute_mint_amount_for_stableswap_deposit(
+            &MIN_AMP,
+            &deposits,
+            &pool_assets,
+            pool_token_supply,
+        )
+        .unwrap();
         let expected_mint_amount = MAX_TOKENS_IN;
 
         assert_eq!(actual_mint_amount, expected_mint_amount);
@@ -1106,48 +1097,44 @@ mod tests {
             deposit_amount_a in 0..MAX_TOKENS_IN.u128() >> 2,
             deposit_amount_b in 0..MAX_TOKENS_IN.u128() >> 2,
             deposit_amount_c in 0..MAX_TOKENS_IN.u128() >> 2,
-            swap_token_a_amount in 0..MAX_TOKENS_IN.u128(),
-            swap_token_b_amount in 0..MAX_TOKENS_IN.u128(),
-            swap_token_c_amount in 0..MAX_TOKENS_IN.u128(),
+            pool_token_a_amount in 0..MAX_TOKENS_IN.u128(),
+            pool_token_b_amount in 0..MAX_TOKENS_IN.u128(),
+            pool_token_c_amount in 0..MAX_TOKENS_IN.u128(),
             pool_token_supply in 0..MAX_TOKENS_IN.u128(),
         ) {
-            let swaps = vec![
-                coin(swap_token_a_amount, "denom1"),
-                coin(swap_token_b_amount, "denom2"),
-                coin(swap_token_c_amount, "denom3"),
+            let pool_assets = vec![
+                coin(pool_token_a_amount, "denom1"),
+                coin(pool_token_b_amount, "denom2"),
+                coin(pool_token_c_amount, "denom3"),
             ];
 
-            let d0 = compute_d(&amp_factor, &swaps).unwrap();
-
+            let d0 = compute_d(&amp_factor, &pool_assets).unwrap();
             let deposits = vec![
                 coin(deposit_amount_a, "denom1"),
                 coin(deposit_amount_b, "denom2"),
                 coin(deposit_amount_c, "denom3"),
             ];
 
-            let mint_amount = compute_mint_amount_for_deposit(
-                &amp_factor,
-                &swaps,
-                &deposits,
-                Uint128::new(pool_token_supply),
-                );
-            prop_assume!(mint_amount.is_some());
-
-            let new_swap_token_a_amount = swap_token_a_amount + deposit_amount_a;
-            let new_swap_token_b_amount = swap_token_b_amount + deposit_amount_b;
-            let new_swap_token_c_amount = swap_token_c_amount + deposit_amount_c;
-            let new_pool_token_supply = pool_token_supply + mint_amount.unwrap().u128();
-
-            let new_swaps = vec![
-                coin(new_swap_token_a_amount, "denom1"),
-                coin(new_swap_token_b_amount, "denom2"),
-                coin(new_swap_token_c_amount, "denom3"),
+            // by the time compute_mint_amount_for_stableswap_deposit is called within the contract
+            // to compute the lp shares for the stableswap, pool assets include the new deposits already
+            let new_pool_assets = vec![
+                coin(pool_token_a_amount + deposit_amount_a, "denom1"),
+                coin(pool_token_b_amount + deposit_amount_b, "denom2"),
+                coin(pool_token_c_amount + deposit_amount_c, "denom3"),
             ];
 
-            let d1 = compute_d(&amp_factor, &new_swaps).unwrap();
+            let mint_amount = compute_mint_amount_for_stableswap_deposit(
+                &amp_factor,
+                &deposits,
+                &new_pool_assets,
+                Uint128::new(pool_token_supply),
+                );
+
+            prop_assume!(mint_amount.is_some());
+
+            let d1 = compute_d(&amp_factor, &new_pool_assets).unwrap();
 
             assert!(d0 < d1);
-            assert!(d0 / Uint512::from( pool_token_supply) <= d1 /  Uint512::from( new_pool_token_supply));
         }
     }
 

--- a/contracts/pool-manager/src/liquidity/commands.rs
+++ b/contracts/pool-manager/src/liquidity/commands.rs
@@ -21,7 +21,9 @@ use crate::{
 // After writing create_pool I see this can get quite verbose so attempting to
 // break it down into smaller modules which house some things like swap, liquidity etc
 use crate::contract::SINGLE_SIDE_LIQUIDITY_PROVISION_REPLY_ID;
-use crate::helpers::{aggregate_outgoing_fees, compute_d, compute_mint_amount_for_deposit};
+use crate::helpers::{
+    aggregate_outgoing_fees, compute_d, compute_mint_amount_for_stableswap_deposit,
+};
 use crate::queries::query_simulation;
 use crate::state::{
     LiquidityProvisionData, SingleSideLiquidityProvisionBuffer,
@@ -291,7 +293,7 @@ pub fn provide_liquidity(
 
                     share
                 } else {
-                    let amount = compute_mint_amount_for_deposit(
+                    let amount = compute_mint_amount_for_stableswap_deposit(
                         amp_factor,
                         &deposits,
                         &pool_assets,

--- a/contracts/pool-manager/src/tests/integration_tests.rs
+++ b/contracts/pool-manager/src/tests/integration_tests.rs
@@ -3355,6 +3355,331 @@ mod provide_liquidity {
         );
     }
 
+    #[test]
+    fn provide_liquidity_stable_swap_shouldnt_double_count_deposits() {
+        let mut suite = TestingSuite::default_with_balances(vec![
+            coin(1_000_000_001u128, "uusd".to_string()),
+            coin(1_000_000_001u128, "uusdc".to_string()),
+            coin(1_000_000_000u128, "uusdt".to_string()),
+            coin(1_000_000_001u128, "uusdy".to_string()),
+        ]);
+        let creator = suite.creator();
+
+        let asset_infos = vec![
+            "uusdc".to_string(),
+            "uusdt".to_string(),
+            "uusdy".to_string(),
+        ];
+
+        // Protocol fee is 0.01% and swap fee is 0.02% and burn fee is 0%
+        let pool_fees = PoolFee {
+            protocol_fee: Fee {
+                share: Decimal::from_ratio(1u128, 1000u128),
+            },
+            swap_fee: Fee {
+                share: Decimal::from_ratio(1u128, 10_000_u128),
+            },
+            burn_fee: Fee {
+                share: Decimal::zero(),
+            },
+            extra_fees: vec![],
+        };
+
+        // Create a pool
+        suite.instantiate_default().create_pool(
+            &creator,
+            asset_infos,
+            vec![6u8, 6u8, 6u8],
+            pool_fees,
+            PoolType::StableSwap { amp: 100 },
+            Some("uusdc.uusdt.uusdy".to_string()),
+            vec![coin(1000, "uusd")],
+            |result| {
+                result.unwrap();
+            },
+        );
+
+        let lp_denom = suite.get_lp_denom("uusdc.uusdt.uusdy".to_string());
+
+        // Let's try to add liquidity
+        suite
+            .provide_liquidity(
+                &creator,
+                "uusdc.uusdt.uusdy".to_string(),
+                None,
+                None,
+                None,
+                None,
+                vec![
+                    Coin {
+                        denom: "uusdc".to_string(),
+                        amount: Uint128::from(500_000u128),
+                    },
+                    Coin {
+                        denom: "uusdt".to_string(),
+                        amount: Uint128::from(500_000u128),
+                    },
+                    Coin {
+                        denom: "uusdy".to_string(),
+                        amount: Uint128::from(500_000u128),
+                    },
+                ],
+                |result| {
+                    result.unwrap();
+                },
+            )
+            .query_balance(&creator.to_string(), &lp_denom, |result| {
+                assert_eq!(
+                    result.unwrap().amount,
+                    // liquidity provided - MINIMUM_LIQUIDITY_AMOUNT
+                    Uint128::from(1_500_000u128 - 1_000u128)
+                );
+            });
+
+        // let's try providing liquidity again
+        suite
+            .provide_liquidity(
+                &creator,
+                "uusdc.uusdt.uusdy".to_string(),
+                None,
+                None,
+                None,
+                None,
+                vec![
+                    Coin {
+                        denom: "uusdc".to_string(),
+                        amount: Uint128::from(500_000u128),
+                    },
+                    Coin {
+                        denom: "uusdt".to_string(),
+                        amount: Uint128::from(500_000u128),
+                    },
+                    Coin {
+                        denom: "uusdy".to_string(),
+                        amount: Uint128::from(500_000u128),
+                    },
+                ],
+                |result| {
+                    result.unwrap();
+                },
+            )
+            .query_balance(&creator.to_string(), &lp_denom, |result| {
+                assert_eq!(
+                    result.unwrap().amount,
+                    // we should expect another ~1_500_000
+                    Uint128::from(1_500_000u128 + 1_500_000u128 - 1_000u128)
+                );
+            });
+
+        let simulated_return_amount = RefCell::new(Uint128::zero());
+        suite.query_simulation(
+            "uusdc.uusdt.uusdy".to_string(),
+            Coin {
+                denom: "uusdc".to_string(),
+                amount: Uint128::from(1_000u128),
+            },
+            "uusdt".to_string(),
+            |result| {
+                *simulated_return_amount.borrow_mut() = result.unwrap().return_amount;
+            },
+        );
+
+        // Now Let's try a swap
+        suite.swap(
+            &creator,
+            "uusdt".to_string(),
+            None,
+            None,
+            None,
+            "uusdc.uusdt.uusdy".to_string(),
+            vec![coin(1_000u128, "uusdc".to_string())],
+            |result| {
+                // Find the key with 'offer_amount' and the key with 'return_amount'
+                // Ensure that the offer amount is 1000 and the return amount is greater than 0
+                let mut return_amount = String::new();
+                let mut offer_amount = String::new();
+
+                for event in result.unwrap().events {
+                    if event.ty == "wasm" {
+                        for attribute in event.attributes {
+                            match attribute.key.as_str() {
+                                "return_amount" => return_amount = attribute.value,
+                                "offer_amount" => offer_amount = attribute.value,
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+                // Because the Pool was created and 1_000_000 of each token has been provided as liquidity
+                // Assuming no fees we should expect a small swap of 1000 to result in not too much slippage
+                // Expect 1000 give or take 0.002 difference
+                // Once fees are added and being deducted properly only the "0.002" should be changed.
+                assert_approx_eq!(
+                    offer_amount.parse::<u128>().unwrap(),
+                    return_amount.parse::<u128>().unwrap(),
+                    "0.002"
+                );
+                assert_approx_eq!(
+                    simulated_return_amount.borrow().u128(),
+                    return_amount.parse::<u128>().unwrap(),
+                    "0.002"
+                );
+            },
+        );
+
+        let simulated_offer_amount = RefCell::new(Uint128::zero());
+        // Now Let's try a reverse simulation by swapping uluna to uwhale
+        suite.query_reverse_simulation(
+            "uusdc.uusdt.uusdy".to_string(),
+            Coin {
+                denom: "uusdc".to_string(),
+                amount: Uint128::from(1000u128),
+            },
+            "uusdt".to_string(),
+            |result| {
+                *simulated_offer_amount.borrow_mut() = result.unwrap().offer_amount;
+            },
+        );
+
+        // Another swap but this time the other way around
+        suite.swap(
+            &creator,
+            "uusdc".to_string(),
+            None,
+            None,
+            None,
+            "uusdc.uusdt.uusdy".to_string(),
+            vec![coin(
+                simulated_offer_amount.borrow().u128(),
+                "uusdt".to_string(),
+            )],
+            |result| {
+                // Find the key with 'offer_amount' and the key with 'return_amount'
+                // Ensure that the offer amount is 1000 and the return amount is greater than 0
+                let mut return_amount = String::new();
+                let mut offer_amount = String::new();
+
+                for event in result.unwrap().events {
+                    if event.ty == "wasm" {
+                        for attribute in event.attributes {
+                            match attribute.key.as_str() {
+                                "return_amount" => return_amount = attribute.value,
+                                "offer_amount" => offer_amount = attribute.value,
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+                assert_approx_eq!(
+                    simulated_offer_amount.borrow().u128(),
+                    offer_amount.parse::<u128>().unwrap(),
+                    "0.002"
+                );
+
+                assert_approx_eq!(1000u128, return_amount.parse::<u128>().unwrap(), "0.003");
+            },
+        );
+
+        // And now uusdc to uusdy
+        suite.query_reverse_simulation(
+            "uusdc.uusdt.uusdy".to_string(),
+            Coin {
+                denom: "uusdy".to_string(),
+                amount: Uint128::from(1000u128),
+            },
+            "uusdc".to_string(),
+            |result| {
+                *simulated_return_amount.borrow_mut() = result.unwrap().offer_amount;
+            },
+        );
+        // Another swap but this time uusdc to uusdy
+        suite.swap(
+            &creator,
+            "uusdy".to_string(),
+            None,
+            None,
+            None,
+            "uusdc.uusdt.uusdy".to_string(),
+            vec![coin(
+                simulated_return_amount.borrow().u128(),
+                "uusdc".to_string(),
+            )],
+            |result| {
+                // Find the key with 'offer_amount' and the key with 'return_amount'
+                // Ensure that the offer amount is 1000 and the return amount is greater than 0
+                let mut return_amount = String::new();
+                let mut offer_amount = String::new();
+
+                for event in result.unwrap().events {
+                    if event.ty == "wasm" {
+                        for attribute in event.attributes {
+                            match attribute.key.as_str() {
+                                "return_amount" => return_amount = attribute.value,
+                                "offer_amount" => offer_amount = attribute.value,
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+                assert_approx_eq!(
+                    simulated_return_amount.borrow().u128(),
+                    return_amount.parse::<u128>().unwrap(),
+                    "0.002"
+                );
+                assert_approx_eq!(1000u128, offer_amount.parse::<u128>().unwrap(), "0.003");
+            },
+        );
+
+        // And now uusdy to uusdt
+        suite.query_reverse_simulation(
+            "uusdc.uusdt.uusdy".to_string(),
+            Coin {
+                denom: "uusdt".to_string(),
+                amount: Uint128::from(1000u128),
+            },
+            "uusdy".to_string(),
+            |result| {
+                *simulated_offer_amount.borrow_mut() = result.unwrap().offer_amount;
+            },
+        );
+        // Another swap but this time uusdy to uusdt
+        suite.swap(
+            &creator,
+            "uusdt".to_string(),
+            None,
+            None,
+            None,
+            "uusdc.uusdt.uusdy".to_string(),
+            vec![coin(
+                simulated_offer_amount.borrow().u128(),
+                "uusdy".to_string(),
+            )],
+            |result| {
+                let mut return_amount = String::new();
+                let mut offer_amount = String::new();
+
+                for event in result.unwrap().events {
+                    if event.ty == "wasm" {
+                        for attribute in event.attributes {
+                            match attribute.key.as_str() {
+                                "return_amount" => return_amount = attribute.value,
+                                "offer_amount" => offer_amount = attribute.value,
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+                assert_approx_eq!(
+                    simulated_offer_amount.borrow().u128(),
+                    offer_amount.parse::<u128>().unwrap(),
+                    "0.002"
+                );
+
+                assert_approx_eq!(1000u128, return_amount.parse::<u128>().unwrap(), "0.003");
+            },
+        );
+    }
+
     // This test is to ensure that the edge case of providing liquidity with 3 assets
     #[test]
     fn provide_liquidity_stable_swap_edge_case() {


### PR DESCRIPTION

## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

Fixes #37 by avoiding double counting the deposits a user made when providing liquidity into a stableswap pool. 

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/MANTRA-Finance/amm/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to MANTRA!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [ ] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Finance/amm/blob/main/docs/CONTRIBUTING.md).
- [ ] My pull request has a sound title and description (not something vague like `Update index.md`)
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation.
- [ ] The code is formatted properly `cargo fmt --all --`.
- [ ] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [ ] I have regenerated the schemas if needed with `just schemas`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced stable swap functionality with improved mint amount calculations.
	- Added a new test to ensure accurate liquidity deposit calculations in stable swap pools.

- **Bug Fixes**
	- Refined logic to prevent double counting of LP shares during liquidity provision.

- **Documentation**
	- Updated comments and code organization for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->