### PR TITLE
refactor: make the farm and position identifier lenght validation <= 66 chars to accomodate UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "farm-manager"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "amm",
  "anyhow",

--- a/contracts/farm-manager/Cargo.toml
+++ b/contracts/farm-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "farm-manager"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Kerber0x <kerber0x@protonmail.com>"]
 edition.workspace = true
 description = "The Farm Manager is a contract that allows to manage multiple pool farms in a single contract."

--- a/contracts/farm-manager/src/helpers.rs
+++ b/contracts/farm-manager/src/helpers.rs
@@ -265,11 +265,14 @@ pub(crate) fn is_farm_expired(
     )
 }
 
+// 64 char hash  + 2 char prefix allowed
+const MAX_IDENTIFIER_LENGTH: usize = 66usize;
+
 /// Validates that farms and positions identifiers are correct, ensuring the identifier doesn't
 /// exceed 64 characters, it's alphanumeric, and can contain '.', '-' and '_'.
 pub fn validate_identifier(identifier: &str) -> Result<(), ContractError> {
     ensure!(
-        identifier.len() <= 64usize
+        identifier.len() <= MAX_IDENTIFIER_LENGTH
             && identifier
                 .chars()
                 .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_'),

--- a/contracts/farm-manager/tests/integration.rs
+++ b/contracts/farm-manager/tests/integration.rs
@@ -6523,7 +6523,10 @@ fn test_farm_and_position_id_validation() {
                         denom: "uusdy".to_string(),
                         amount: Uint128::new(8_000u128),
                     },
-                    farm_identifier: Some("71059201816354683642937887892647".to_string()),
+                    farm_identifier: Some(
+                        "7105920181635468364293788789264771059201816354683642937887892647"
+                            .to_string(),
+                    ),
                 },
             },
             vec![coin(8_000, "uusdy"), coin(1_000, "uom")],


### PR DESCRIPTION

## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

This PR changes the validation of the farm and position identifier on the farm manager to accept identifiers of at most 66 chars. This is to accommodate the UI where a 64 char hash is being used as identifier + 2 chars of prefix the contract prepends.

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/MANTRA-Finance/amm/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to MANTRA!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Finance/amm/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed with `just schemas`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased maximum identifier length for validation from 64 to 66 characters.
	- Added a comprehensive set of integration tests for farm management functionalities, covering various scenarios.

- **Bug Fixes**
	- Improved validation logic to ensure identifiers meet new length requirements.

- **Chores**
	- Updated version number from 0.1.2 to 0.1.3 in project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->