### PR TITLE
refactor(farm_manager): remove rewards validation on position withdrawal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "farm-manager"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "amm",
  "anyhow",

--- a/contracts/farm-manager/Cargo.toml
+++ b/contracts/farm-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "farm-manager"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Kerber0x <kerber0x@protonmail.com>"]
 edition.workspace = true
 description = "The Farm Manager is a contract that allows to manage multiple pool farms in a single contract."


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

It didn't make sense to verify if the user had pending rewards when withdrawing a position due to the following reasons:

- Closed positions don't accumulate rewards.
- If an open position was going to be withdrawn with the emergency unlock, the user would forfeit its rewards anyway.
- Withdrawing an open position with the emergency unlock updates the weights on the contract, which was the main reason why the user was force to claim rewards in the first place.
- Ultimately, it would prevent users to withdraw closed positions easily without taking an additional action on their open positions.

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/MANTRA-Finance/amm/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to MANTRA!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Finance/amm/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x]  The code is formatted properly `cargo fmt --all --`.
- [x]  Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed with `just schemas`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an emergency withdrawal option, allowing users to withdraw funds before a position expires, subject to a penalty fee.
- **Bug Fixes**
	- Enhanced error handling in integration tests for various scenarios, ensuring more robust validation of farm and position management.
- **Tests**
	- Added new integration tests to verify the functionality of emergency withdrawals and weight updates after withdrawals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->