### PR TITLE
chore: add extra fees when doing reverse query simulation

### DIFF
--- a/contracts/pool-manager/src/helpers.rs
+++ b/contracts/pool-manager/src/helpers.rs
@@ -338,11 +338,15 @@ pub fn compute_offer_amount(
 
     // ask => offer
     // offer_amount = cp / (ask_pool - ask_amount / (1 - fees)) - offer_pool
-    let fees = pool_fees
+    let mut fees = pool_fees
         .swap_fee
         .to_decimal_256()
         .checked_add(pool_fees.protocol_fee.to_decimal_256())?
         .checked_add(pool_fees.burn_fee.to_decimal_256())?;
+
+    for extra_fee in pool_fees.extra_fees.iter() {
+        fees = fees.checked_add(extra_fee.to_decimal_256())?;
+    }
 
     let one_minus_commission = Decimal256::one() - fees;
     let inv_one_minus_commission = Decimal256::one() / one_minus_commission;

--- a/scripts/get_artifacts_versions.sh
+++ b/scripts/get_artifacts_versions.sh
@@ -4,7 +4,7 @@ set -e
 project_root_path=$(realpath "$0" | sed 's|\(.*\)/.*|\1|' | cd ../ | pwd)
 
 if [ "$1" != "--skip-verbose" ]; then
-  echo -e "\nGetting artifacts versions...\n"
+	echo -e "\nGetting artifacts versions...\n"
 fi
 
 echo -e "\033[1mContracts:\033[0m"
@@ -20,8 +20,8 @@ done
 echo -e "\n\033[1mPackages:\033[0m"
 
 for package in packages/*; do
-  version=$(cat ''"$package"'/Cargo.toml' | awk -F= '/^version/ { print $2 }')
-  version="${version//\"/}"
+	version=$(cat ''"$package"'/Cargo.toml' | awk -F= '/^version/ { print $2 }')
+	version="${version//\"/}"
 
-  printf "%-20s %s\n" "$(basename $package)" ": $version"
+	printf "%-20s %s\n" "$(basename $package)" ": $version"
 done


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

The extra fees were not being considered when doing reverse simulation queries. This fixes that. 

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/MANTRA-Finance/amm/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to MANTRA!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Finance/amm/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed with `just schemas`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced fee calculation for pool's swap operations, ensuring all applicable fees are considered in the offer amount.
  
- **Bug Fixes**
	- Improved clarity in comments related to fee calculations.

- **Style**
	- Adjusted formatting in the artifact version retrieval script for better code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->