### PR TITLE
ci: fix tarpaulin action

### DIFF
--- a/.github/workflows/ci-test-lints.yaml
+++ b/.github/workflows/ci-test-lints.yaml
@@ -25,11 +25,19 @@ jobs:
           target: wasm32-unknown-unknown
           override: true
 
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
+#    - name: Run cargo-tarpaulin
+#      uses: actions-rs/tarpaulin@v0.1
+#      with:
+#        version: "0.22.0"
+#        args: '--locked -- --test-threads 4'
+
+      - name: Rune tests
+        uses: actions-rs/cargo@v1
         with:
-          version: "0.15.0"
-          args: '--locked -- --test-threads 4'
+          command: test
+          args: --no-fail-fast --locked
+        env:
+          RUST_BACKTRACE: 1
 
   lints:
     name: Lints


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

This PR disables the tarpaulin github action. Tests are run with `cargo test` instead.  

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/MANTRA-Finance/amm/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to MANTRA!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Chain/mantra-dex/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed with `just schemas`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to use the latest version of `cargo-tarpaulin` for code coverage testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->