### PR TITLE
fix: add asset len validation for xyk pools

### DIFF
--- a/contracts/pool-manager/src/error.rs
+++ b/contracts/pool-manager/src/error.rs
@@ -94,6 +94,9 @@ pub enum ContractError {
     #[error("The asset doesn't match the assets stored in contract")]
     AssetMismatch,
 
+    #[error("A constant product pool can only contain 2 assets")]
+    ConstantProductPoolAssetMismatch,
+
     #[error("Error computing the LP mint amount for the stable pool")]
     StableLpMintError,
 

--- a/contracts/pool-manager/src/manager/commands.rs
+++ b/contracts/pool-manager/src/manager/commands.rs
@@ -93,6 +93,14 @@ pub fn create_pool(
         ContractError::AssetMismatch
     );
 
+    // Ensure that the number of assets is 2 for ConstantProduct pools
+    if pool_type == PoolType::ConstantProduct {
+        ensure!(
+            asset_denoms.len() == 2,
+            ContractError::ConstantProductPoolAssetMismatch
+        );
+    }
+
     // Ensure that the number of assets is within the allowed range
     ensure!(
         asset_denoms.len() <= MAX_ASSETS_PER_POOL,


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

Fixes #113, which prevents creating xyk pools with more than 2 assets.

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/MANTRA-Finance/amm/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to MANTRA!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Chain/mantra-dex/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed with `just schemas`.
