### PR TITLE
fix: prevent farms to be created in the past

### DIFF
--- a/contracts/farm-manager/src/helpers.rs
+++ b/contracts/farm-manager/src/helpers.rs
@@ -133,8 +133,9 @@ pub(crate) fn validate_farm_epochs(
     // assert epoch params are correctly set
     let start_epoch = params.start_epoch.unwrap_or(current_epoch + 1u64);
 
+    // ensure that start date is set in the future, at least current_epoch + 1u64
     ensure!(
-        start_epoch > 0u64,
+        start_epoch > current_epoch,
         ContractError::InvalidEpoch {
             which: "start".to_string()
         }

--- a/contracts/farm-manager/tests/integration.rs
+++ b/contracts/farm-manager/tests/integration.rs
@@ -145,6 +145,34 @@ fn create_farms() {
     let other = suite.senders[1].clone();
     let fee_collector = suite.fee_collector_addr.clone();
 
+    suite.manage_farm(
+        &other,
+        FarmAction::Fill {
+            params: FarmParams {
+                lp_denom: lp_denom.clone(),
+                // current epoch is 0
+                start_epoch: Some(0),
+                preliminary_end_epoch: None,
+                curve: None,
+                farm_asset: Coin {
+                    denom: "uusdy".to_string(),
+                    amount: Uint128::new(4_000u128),
+                },
+                farm_identifier: None,
+            },
+        },
+        vec![coin(4_000, "uusdy"), coin(1_000, "uom")],
+        |result| {
+            let err = result.unwrap_err().downcast::<ContractError>().unwrap();
+            match err {
+                ContractError::InvalidEpoch { which } => {
+                    assert_eq!(which, "start")
+                }
+                _ => panic!("Wrong error type, should return ContractError::InvalidEpoch"),
+            }
+        },
+    );
+
     for _ in 0..10 {
         suite.add_one_epoch();
     }
@@ -397,10 +425,38 @@ fn create_farms() {
             vec![coin(4_000, "uusdy"), coin(1_000, "uom")],
             |result| {
                 let err = result.unwrap_err().downcast::<ContractError>().unwrap();
-
                 match err {
-                    ContractError::FarmEndsInPast { .. } => {}
-                    _ => panic!("Wrong error type, should return ContractError::FarmEndsInPast"),
+                    ContractError::InvalidEpoch { which } => {
+                        assert_eq!(which, "start")
+                    }
+                    _ => panic!("Wrong error type, should return ContractError::InvalidEpoch"),
+                }
+            },
+        )
+        .manage_farm(
+            &other,
+            FarmAction::Fill {
+                params: FarmParams {
+                    lp_denom: lp_denom.clone(),
+                    // current epoch is 10
+                    start_epoch: None,
+                    preliminary_end_epoch: Some(5),
+                    curve: None,
+                    farm_asset: Coin {
+                        denom: "uusdy".to_string(),
+                        amount: Uint128::new(4_000u128),
+                    },
+                    farm_identifier: None,
+                },
+            },
+            vec![coin(4_000, "uusdy"), coin(1_000, "uom")],
+            |result| {
+                let err = result.unwrap_err().downcast::<ContractError>().unwrap();
+                match err {
+                    ContractError::FarmStartTimeAfterEndTime { .. } => {}
+                    _ => panic!(
+                        "Wrong error type, should return ContractError::FarmStartTimeAfterEndTime"
+                    ),
                 }
             },
         )
@@ -8586,4 +8642,55 @@ fn farm_owners_get_penalty_fees() {
         .query_balance(lp_denom_1.clone(), &bob, |balance| {
             assert_eq!(balance, Uint128::new(1_000_000_000u128 + 25u128));
         });
+}
+
+#[test]
+fn farm_cant_be_created_in_the_past() {
+    let lp_denom = format!("factory/{MOCK_CONTRACT_ADDR_1}/{LP_SYMBOL}").to_string();
+    let invalid_lp_denom = format!("factory/{MOCK_CONTRACT_ADDR_2}/{LP_SYMBOL}").to_string();
+
+    let mut suite = TestingSuite::default_with_balances(vec![
+        coin(1_000_000_000u128, "uom".to_string()),
+        coin(1_000_000_000u128, "uusdy".to_string()),
+        coin(1_000_000_000u128, "uosmo".to_string()),
+        coin(1_000_000_000u128, lp_denom.clone()),
+        coin(1_000_000_000u128, invalid_lp_denom.clone()),
+    ]);
+    suite.instantiate_default();
+
+    let other = suite.senders[1].clone();
+
+    for _ in 0..10 {
+        suite.add_one_epoch();
+    }
+    // current epoch is 10
+
+    // We can create a farm in a past epoch
+    suite.manage_farm(
+        &other,
+        FarmAction::Fill {
+            params: FarmParams {
+                lp_denom: lp_denom.clone(),
+                start_epoch: Some(1), // start epoch in the past
+                preliminary_end_epoch: Some(28),
+                curve: None,
+                farm_asset: Coin {
+                    denom: "uusdy".to_string(),
+                    amount: Uint128::new(4_000u128),
+                },
+                farm_identifier: Some("farm_1".to_string()),
+            },
+        },
+        vec![coin(4_000, "uusdy"), coin(1_000, "uom")],
+        |result| {
+            let err = result.unwrap_err().downcast::<ContractError>().unwrap();
+
+            match err {
+                ContractError::InvalidEpoch { which } => {
+                    assert_eq!(which, "start")
+                }
+                _ => panic!("Wrong error type, should return ContractError::InvalidEpoch"),
+            }
+        },
+    );
 }


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

Fixes #117 , improving the epoch validation.

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/MANTRA-Finance/amm/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to MANTRA!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Chain/mantra-dex/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed with `just schemas`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced validation for farm creation to ensure start epochs are set in the future.
- **Tests**
	- Added integration test to verify that farms cannot be created with a start epoch in the past.
- **Bug Fixes**
	- Improved epoch validation logic to ensure farms can only be created for future epochs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->