### PR TITLE
fix(farm_manager): mitigate potential divide-by-zero error when claiming rewards

### DIFF
--- a/contracts/farm-manager/src/farm/commands.rs
+++ b/contracts/farm-manager/src/farm/commands.rs
@@ -202,6 +202,11 @@ pub(crate) fn calculate_rewards(
                 .unwrap_or(&Uint128::zero())
                 .to_owned();
 
+            // skip epoch if the total lp weight is zero
+            if total_lp_weight.is_zero() {
+                continue;
+            }
+
             let user_share = (user_weight, total_lp_weight);
 
             let reward = farm_emissions


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

Fixes #119 by making sure epochs where `contract_weight` is 0 are being skipped on the rewards computation.

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/MANTRA-Finance/amm/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to MANTRA!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Chain/mantra-dex/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed with `just schemas`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of reward calculations when total LP weight is zero
  - Prevented potential divide-by-zero errors during rewards processing

- **Tests**
  - Added test cases to verify robust handling of edge cases in reward calculations
  - Ensured correct rewards processing when users have multiple or closed positions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->