### PR TITLE
fix: close farms via submsg to prevent potential bricking

### DIFF
--- a/contracts/farm-manager/tests/common/suite.rs
+++ b/contracts/farm-manager/tests/common/suite.rs
@@ -1,5 +1,7 @@
 use cosmwasm_std::testing::MockStorage;
-use cosmwasm_std::{coin, Addr, Coin, Decimal, Empty, StdResult, Timestamp, Uint128, Uint64};
+use cosmwasm_std::{
+    coin, Addr, BankMsg, Coin, Decimal, Empty, StdResult, Timestamp, Uint128, Uint64,
+};
 use cw_multi_test::{
     App, AppBuilder, AppResponse, BankKeeper, DistributionKeeper, Executor, FailingModule,
     GovFailingModule, IbcFailingModule, MockApiBech32, StakeKeeper, WasmKeeper,
@@ -289,6 +291,19 @@ impl TestingSuite {
             "Farm Manager",
             Some(creator.into_string()),
         ));
+
+        self
+    }
+    #[track_caller]
+    pub(crate) fn burn_tokens(
+        &mut self,
+        address: &Addr,
+        coin: Vec<Coin>,
+        result: impl Fn(Result<AppResponse, anyhow::Error>),
+    ) -> &mut Self {
+        let msg = BankMsg::Burn { amount: coin };
+
+        result(self.app.execute(address.clone(), msg.into()));
 
         self
     }

--- a/contracts/farm-manager/tests/common/suite_contracts.rs
+++ b/contracts/farm-manager/tests/common/suite_contracts.rs
@@ -8,6 +8,7 @@ pub fn farm_manager_contract() -> Box<dyn Contract<Empty>> {
         farm_manager::contract::instantiate,
         farm_manager::contract::query,
     )
+    .with_reply(farm_manager::contract::reply)
     .with_migrate(farm_manager::contract::migrate);
 
     Box::new(contract)


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

Fixes #130 by closing farms using a SubMsg, bypassing the tx failure in case a malicious TF token freezes token transfers via hooks. 

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/MANTRA-Finance/amm/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to MANTRA!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Chain/mantra-dex/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `just fmt`.
- [x] Clippy doesn't report any issues `just lint`.
- [x] I have regenerated the schemas if needed with `just schemas`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new reply handler to manage asynchronous responses with actionable outcomes.
  - Improved messaging for farm management by transitioning to enhanced submessage processing.
  
- **Tests**
  - Added functionality for token burning to support advanced testing scenarios.
  - Implemented a new integration test to ensure reliable farm closure despite potential disruptions from malicious tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->