### PR TITLE
fix(pool_manager): round up when doing the reverse query so the swap …

### DIFF
--- a/contracts/pool-manager/src/helpers.rs
+++ b/contracts/pool-manager/src/helpers.rs
@@ -355,11 +355,13 @@ pub fn compute_offer_amount(
     let offer_amount: Uint256 = Uint256::one()
         .multiply_ratio(
             cp,
-            ask_asset_in_pool.checked_sub(
-                Decimal256::from_ratio(ask_amount, Uint256::one())
-                    .checked_mul(inv_one_minus_commission)?
-                    .to_uint_floor(),
-            )?,
+            ask_asset_in_pool
+                .checked_sub(
+                    Decimal256::from_ratio(ask_amount, Uint256::one())
+                        .checked_mul(inv_one_minus_commission)?
+                        .to_uint_floor(),
+                )?
+                .checked_sub(Uint256::one())?,
         )
         .checked_sub(offer_asset_in_pool)?;
 


### PR DESCRIPTION
…returns expected returns

## Description and Motivation

Fixes #132  by rounding up when computing the needed amount in reversed swap simulations.

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/MANTRA-Finance/amm/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to MANTRA!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Chain/mantra-dex/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `just fmt`.
- [x] Clippy doesn't report any issues `just lint`.
- [x] I have regenerated the schemas if needed with `just schemas`.
