### PR TITLE
fix: stable slippage assertion

### DIFF
--- a/contracts/pool-manager/src/helpers.rs
+++ b/contracts/pool-manager/src/helpers.rs
@@ -445,11 +445,9 @@ pub fn assert_slippage_tolerance(
 
                 let pool_ratio = Decimal256::from_ratio(pools_total, total_share);
                 let deposit_ratio = Decimal256::from_ratio(deposits_total, share);
+                let difference = pool_ratio.abs_diff(deposit_ratio);
 
-                // the slippage tolerance for the stableswap can't use a simple ratio for calculating
-                // slippage when adding liquidity. Due to the math behind the stableswap, the amp factor
-                // needs to be in as well, much like when swaps are done
-                if pool_ratio * one_minus_slippage_tolerance > deposit_ratio {
+                if pool_ratio * one_minus_slippage_tolerance > difference {
                     return Err(ContractError::MaxSlippageAssertion);
                 }
             }


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

Fixes #138 .

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/MANTRA-Finance/amm/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to MANTRA!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Chain/mantra-dex/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `just fmt`.
- [x] Clippy doesn't report any issues `just lint`.
- [x] I have regenerated the schemas if needed with `just schemas`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Revised the validation logic for liquidity operations, ensuring that slippage tolerance is now calculated more precisely. This update may influence when errors are raised during transactions.
- **Tests**
	- Added an integration test to verify that attempts to provide liquidity with overly strict slippage conditions correctly trigger an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->