### PR TITLE
fix: farm expansion assertion to prevent users losing rewards

### DIFF
--- a/contracts/farm-manager/src/manager/commands.rs
+++ b/contracts/farm-manager/src/manager/commands.rs
@@ -237,6 +237,18 @@ fn expand_farm(
 
     let config = CONFIG.load(deps.storage)?;
 
+    let current_epoch = mantra_dex_std::epoch_manager::get_current_epoch(
+        deps.as_ref(),
+        config.epoch_manager_addr.clone().into_string(),
+    )?;
+
+    // ensure the current epoch is at least the preliminary_end_epoch - 1
+    // to prevent edge case of users losing rewards if they entered at the wrong time
+    ensure!(
+        current_epoch.id < farm.preliminary_end_epoch,
+        ContractError::FarmAlreadyExpired
+    );
+
     // check if the farm has already expired, can't be expanded
     ensure!(
         !is_farm_expired(&farm, deps.as_ref(), &env, &config)?,


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

Fixes #146 .

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/MANTRA-Finance/amm/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to MANTRA!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Chain/mantra-dex/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `just fmt`.
- [x] Clippy doesn't report any issues `just lint`.
- [x] I have regenerated the schemas if needed with `just schemas`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced validations during farm expansion to prevent operations when nearing expiration, helping to safeguard user rewards.
- **Tests**
	- Introduced comprehensive tests to verify that expansions cannot occur too late and that reward claiming functions reliably during overlapping operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->