### PR TITLE
Fix/penalty fees sharing

### DIFF
--- a/contracts/farm-manager/tests/common/suite.rs
+++ b/contracts/farm-manager/tests/common/suite.rs
@@ -161,6 +161,35 @@ impl TestingSuite {
         self
     }
 
+    #[track_caller]
+    pub(crate) fn instantiate_long_epoch_buffer(&mut self) -> &mut Self {
+        self.create_epoch_manager();
+        self.create_fee_collector();
+
+        // April 4th 2024 15:00:00 UTC
+        let timestamp = Timestamp::from_seconds(1_712_242_800u64);
+        self.set_time(timestamp);
+
+        // instantiates the farm manager contract
+        self.instantiate(
+            self.fee_collector_addr.to_string(),
+            self.epoch_manager_addr.to_string(),
+            self.pool_manager_addr.to_string(),
+            Coin {
+                denom: "uom".to_string(),
+                amount: Uint128::new(1_000u128),
+            },
+            2,
+            40,
+            86_400,
+            31_556_926u64,
+            MONTH_IN_SECONDS,
+            Decimal::percent(10), //10% penalty
+        );
+
+        self
+    }
+
     #[allow(clippy::inconsistent_digit_grouping)]
     fn create_epoch_manager(&mut self) {
         let epoch_manager_contract = self.app.store_code(epoch_manager_contract());

--- a/contracts/farm-manager/tests/integration.rs
+++ b/contracts/farm-manager/tests/integration.rs
@@ -4234,11 +4234,11 @@ fn test_emergency_withdrawal_with_proportional_penalty() {
             assert_eq!(balance, Uint128::new(999_999_950));
         })
         .query_balance(lp_denom.clone().to_string(), &creator, |balance| {
-            // The creator of the farm gets a cut
-            assert_eq!(balance, Uint128::new(1_000_000_000u128 + 25u128));
+            // Since the farm is not active, the creator of the farm does not gets a cut
+            assert_eq!(balance, Uint128::new(1_000_000_000u128));
         })
         .query_balance(lp_denom.clone().to_string(), &fee_collector, |balance| {
-            assert_eq!(balance, Uint128::new(25));
+            assert_eq!(balance, Uint128::new(50));
         });
 
     suite
@@ -4269,11 +4269,11 @@ fn test_emergency_withdrawal_with_proportional_penalty() {
             assert_eq!(balance, Uint128::new(999_999_100));
         })
         .query_balance(lp_denom_2.clone().to_string(), &fee_collector, |balance| {
-            assert_eq!(balance, Uint128::new(450));
+            assert_eq!(balance, Uint128::new(900));
         })
         .query_balance(lp_denom_2.clone().to_string(), &creator, |balance| {
-            // The creator of the farm gets a cut
-            assert_eq!(balance, Uint128::new(1_000_000_000u128 + 450));
+            // The creator of the farm does not gets a cut since the farm is not active
+            assert_eq!(balance, Uint128::new(1_000_000_000u128));
         });
 }
 

--- a/contracts/farm-manager/tests/integration.rs
+++ b/contracts/farm-manager/tests/integration.rs
@@ -2339,7 +2339,7 @@ pub fn test_manage_position() {
             },
         )
         .query_balance(lp_denom.clone().to_string(), &fee_collector, |balance| {
-            assert_eq!(balance, Uint128::new(250));
+            assert_eq!(balance, Uint128::new(500));
         });
 
     // trying to open a position with an invalid lp which has not been created by the pool manager
@@ -4387,7 +4387,7 @@ fn test_emergency_withdrawal_with_pending_rewards_are_lost() {
 }
 
 #[test]
-fn emergency_withdrawal_shares_penalty_with_farm_owners() {
+fn emergency_withdrawal_shares_penalty_with_active_farm_owners() {
     let lp_denom = format!("factory/{MOCK_CONTRACT_ADDR_1}/{LP_SYMBOL}").to_string();
 
     let mut suite = TestingSuite::default_with_balances(vec![
@@ -4484,6 +4484,7 @@ fn emergency_withdrawal_shares_penalty_with_farm_owners() {
                 );
             },
         )
+        .add_one_epoch()
         .query_balance(lp_denom.clone().to_string(), &other, |balance| {
             assert_eq!(balance, Uint128::new(1_000_000_000));
         })
@@ -5009,7 +5010,7 @@ fn test_multiple_farms_and_positions() {
             &fee_collector_addr,
             |balance| {
                 // 10% of the lp the user input initially
-                assert_eq!(balance, Uint128::new(4_000));
+                assert_eq!(balance, Uint128::new(8_000));
             },
         );
 


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

Fixes #149 .

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/MANTRA-Finance/amm/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to MANTRA!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Chain/mantra-dex/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `just fmt`.
- [x] Clippy doesn't report any issues `just lint`.
- [x] I have regenerated the schemas if needed with `just schemas`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The withdrawal process has been enhanced to ensure that only eligible, active positions participate in penalty fee distribution during emergency operations.
  - A new method for instantiating the farm manager with a longer epoch buffer has been added, providing more flexibility in testing environments.

- **Tests**
  - Updated emergency withdrawal test case to reflect new penalty distribution logic based on farm activity.
  - Adjusted balance assertions for both creator and fee collector to align with the updated penalty fee structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->