### PR TITLE
chore(farm_manager): add proportional emergency penalty when withdrawing a position

### DIFF
--- a/contracts/farm-manager/tests/common/suite.rs
+++ b/contracts/farm-manager/tests/common/suite.rs
@@ -73,6 +73,14 @@ impl TestingSuite {
         self
     }
 
+    pub(crate) fn add_hours(&mut self, hours: u64) -> &mut Self {
+        let mut block_info = self.app.block_info();
+        block_info.time = block_info.time.plus_hours(hours);
+        self.app.set_block(block_info);
+
+        self
+    }
+
     pub(crate) fn send_tokens(
         &mut self,
         sender: &Addr,


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

Fixes #151 .

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/MANTRA-Finance/amm/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to MANTRA!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Chain/mantra-dex/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `just fmt`.
- [x] Clippy doesn't report any issues `just lint`.
- [x] I have regenerated the schemas if needed with `just schemas`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced emergency withdrawal functionality with improved penalty calculations using adjustable, time-based factors.
  - Introduced simulation capabilities that allow precise time adjustments for better handling of duration-related behaviors.

- **Tests**
  - Added integration tests to ensure accurate penalty distribution and fee allocation during emergency withdrawal scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->