### PR TITLE
chore: disable stableswaps temporarily

### DIFF
--- a/contracts/pool-manager/src/manager/commands.rs
+++ b/contracts/pool-manager/src/manager/commands.rs
@@ -1,5 +1,6 @@
 use cosmwasm_std::{
-    attr, ensure, Attribute, BankMsg, Coin, CosmosMsg, DepsMut, Env, MessageInfo, Response, Uint128,
+    attr, ensure, Attribute, BankMsg, Coin, CosmosMsg, DepsMut, Env, MessageInfo, Response,
+    StdError, Uint128,
 };
 
 use mantra_dex_std::coin::is_factory_token;
@@ -82,6 +83,12 @@ pub fn create_pool(
     pool_type: PoolType,
     pool_identifier: Option<String>,
 ) -> Result<Response, ContractError> {
+    //todo remove when the stableswap issues are mitigated
+    ensure!(
+        matches!(pool_type, PoolType::ConstantProduct),
+        StdError::generic_err("Only xyk pools are supported at the moment")
+    );
+
     // Load config for pool creation fee
     let config: Config = CONFIG.load(deps.storage)?;
 

--- a/contracts/pool-manager/src/tests/integration_tests.rs
+++ b/contracts/pool-manager/src/tests/integration_tests.rs
@@ -440,19 +440,74 @@ mod pool_creation_failures {
                    result.unwrap();
                 },
             )
-            .create_pool(
-                &creator,
-                vec!["uom".to_string(), "uusdc".to_string(), "uusd".to_string()],
-                vec![6u8, 6u8, 6u8],
-                pool_fees.clone(),
-                PoolType::StableSwap { amp: 85 },
-                None,
-                vec![coin(1000, "uusd"), coin(8888, "uom")],
-                |result| {
-                    result.unwrap();
-                },
-            )
+
+            //todo remove when the stableswap issues are mitigated
+            // .create_pool(
+            //     &creator,
+            //     vec!["uom".to_string(), "uusdc".to_string(), "uusd".to_string()],
+            //     vec![6u8, 6u8, 6u8],
+            //     pool_fees.clone(),
+            //     PoolType::StableSwap { amp: 85 },
+            //     None,
+            //     vec![coin(1000, "uusd"), coin(8888, "uom")],
+            //     |result| {
+            //         result.unwrap();
+            //     },
+            // )
         ;
+    }
+
+    //todo remove when the stableswap issues are mitigated
+    #[test]
+    fn cant_create_stable_pools() {
+        let mut suite = TestingSuite::default_with_balances(
+            vec![
+                coin(1_000_000_001u128, "uwhale".to_string()),
+                coin(1_000_000_000u128, "uluna".to_string()),
+                coin(1_000_000_001u128, "uusd".to_string()),
+                coin(1_000_000_001u128, "uusdc".to_string()),
+                coin(1_000_000_001u128, "uom".to_string()),
+            ],
+            StargateMock::new(vec![coin(8888u128, "uom".to_string())]),
+        );
+        let creator = suite.creator();
+
+        let pool_fees = PoolFee {
+            protocol_fee: Fee {
+                share: Decimal::zero(),
+            },
+            swap_fee: Fee {
+                share: Decimal::zero(),
+            },
+            burn_fee: Fee {
+                share: Decimal::zero(),
+            },
+            extra_fees: vec![],
+        };
+
+        // Create a pool
+        suite.instantiate_default().add_one_epoch().create_pool(
+            &creator,
+            vec!["uom".to_string(), "uusdc".to_string(), "uusd".to_string()],
+            vec![6u8, 6u8, 6u8],
+            pool_fees.clone(),
+            PoolType::StableSwap { amp: 85 },
+            None,
+            vec![coin(1000, "uusd"), coin(8888, "uom")],
+            |result| {
+                let err = result.unwrap_err().downcast::<ContractError>().unwrap();
+                match err {
+                    ContractError::Std(e) => {
+                        assert!(e
+                            .to_string()
+                            .contains("Only xyk pools are supported at the moment"));
+                    }
+                    _ => {
+                        panic!("Wrong error type, should return ContractError::Std")
+                    }
+                }
+            },
+        );
     }
 
     #[test]
@@ -2799,7 +2854,8 @@ mod swapping {
             });
     }
 
-    #[test]
+    //todo remove when the stableswap issues are mitigated
+    //#[test]
     fn basic_swapping_test_stable_swap_two_assets() {
         let mut suite = TestingSuite::default_with_balances(
             vec![
@@ -5993,7 +6049,8 @@ mod provide_liquidity {
             });
     }
 
-    #[test]
+    //todo remove when the stableswap issues are mitigated
+    //#[test]
     fn provide_liquidity_stable_swap() {
         let mut suite = TestingSuite::default_with_balances(
             vec![
@@ -6282,7 +6339,8 @@ mod provide_liquidity {
         );
     }
 
-    #[test]
+    //todo remove when the stableswap issues are mitigated
+    //#[test]
     fn provide_liquidity_stable_swap_shouldnt_double_count_deposits_or_inflate_lp() {
         let mut suite = TestingSuite::default_with_balances(
             vec![
@@ -6683,8 +6741,9 @@ mod provide_liquidity {
             });
     }
 
+    //todo remove when the stableswap issues are mitigated
     // This test is to ensure that the edge case of providing liquidity with 3 assets
-    #[test]
+    //#[test]
     fn provide_liquidity_stable_swap_edge_case() {
         let mut suite = TestingSuite::default_with_balances(
             vec![
@@ -6983,7 +7042,8 @@ mod provide_liquidity {
             });
     }
 
-    #[test]
+    //todo remove when the stableswap issues are mitigated
+    //#[test]
     fn provide_incomplete_liquidity_fails_on_stableswaps() {
         let mut suite = TestingSuite::default_with_balances(
             vec![
@@ -7215,7 +7275,8 @@ mod provide_liquidity {
         );
     }
 
-    #[test]
+    //todo remove when the stableswap issues are mitigated
+    //#[test]
     fn provide_liquidity_stable_invalid_slippage_check() {
         let mut suite = TestingSuite::default_with_balances(
             vec![
@@ -8141,7 +8202,8 @@ mod multiple_pools {
             );
     }
 
-    #[test]
+    //todo remove when the stableswap issues are mitigated
+    //#[test]
     fn cant_create_pool_with_large_number_of_assets() {
         let mut suite = TestingSuite::default_with_balances(
             vec![
@@ -8295,15 +8357,10 @@ mod multiple_pools {
             .add_one_epoch()
             .create_pool(
                 &creator,
-                vec![
-                    "uusdy".to_string(),
-                    "uusdc".to_string(),
-                    "uusdt".to_string(),
-                    "uusd".to_string(),
-                ],
-                vec![6u8, 6u8, 6u8, 6u8],
+                vec!["uom".to_string(), "uusdt".to_string()],
+                vec![6u8, 6u8],
                 pool_fees.clone(),
-                PoolType::StableSwap { amp: 80 },
+                PoolType::ConstantProduct,
                 Some("1".to_string()),
                 vec![coin(1000, "uusd"), coin(8888, "uom")],
                 |result| {
@@ -8335,15 +8392,10 @@ mod multiple_pools {
 
         suite.create_pool(
             &creator,
-            vec![
-                "uusdy".to_string(),
-                "uusdc".to_string(),
-                "uusdt".to_string(),
-                "uusd".to_string(),
-            ],
-            vec![6u8, 6u8, 6u8, 6u8],
+            vec!["uom".to_string(), "uusdt".to_string()],
+            vec![6u8, 6u8],
             pool_fees.clone(),
-            PoolType::StableSwap { amp: 80 },
+            PoolType::ConstantProduct,
             Some("1".to_string()),
             vec![coin(1000, "uusd"), coin(8888, "uom")],
             |result| {
@@ -8369,6 +8421,143 @@ mod query_simulations {
 
     use crate::tests::suite::TestingSuite;
 
+    #[test]
+    fn simulation_queries_fees_verification() {
+        let mut suite = TestingSuite::default_with_balances(
+            vec![
+                coin(1_000_000_001u128, "uwhale".to_string()),
+                coin(1_000_000_000u128, "uluna".to_string()),
+                coin(1_000_000_001u128, "uusd".to_string()),
+                coin(1_000_000_001u128, "uusdc".to_string()),
+                coin(1_000_000_001u128, "uom".to_string()),
+            ],
+            StargateMock::new(vec![coin(8888u128, "uom".to_string())]),
+        );
+        let creator = suite.creator();
+        let _other = suite.senders[1].clone();
+        let _unauthorized = suite.senders[2].clone();
+        // Asset infos with uwhale and uluna
+
+        let asset_infos = vec!["uwhale".to_string(), "uluna".to_string()];
+
+        // protocol fee 1%
+        // swap fee 2%
+        // burn fee 3%
+        // extra fee 4%
+        let pool_fees = PoolFee {
+            protocol_fee: Fee {
+                share: Decimal::percent(1u64),
+            },
+            swap_fee: Fee {
+                share: Decimal::percent(2u64),
+            },
+            burn_fee: Fee {
+                share: Decimal::percent(3u64),
+            },
+            extra_fees: vec![Fee {
+                share: Decimal::percent(4u64),
+            }],
+        };
+
+        // Create a pool
+        suite.instantiate_default().add_one_epoch().create_pool(
+            &creator,
+            asset_infos,
+            vec![6u8, 6u8],
+            pool_fees.clone(),
+            PoolType::ConstantProduct,
+            Some("whale.uluna".to_string()),
+            vec![coin(1000, "uusd"), coin(8888, "uom")],
+            |result| {
+                result.unwrap();
+            },
+        );
+
+        // Let's try to add liquidity
+        suite.provide_liquidity(
+            &creator,
+            "o.whale.uluna".to_string(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            vec![
+                Coin {
+                    denom: "uwhale".to_string(),
+                    amount: Uint128::from(1000000u128),
+                },
+                Coin {
+                    denom: "uluna".to_string(),
+                    amount: Uint128::from(1000000u128),
+                },
+            ],
+            |result| {
+                result.unwrap();
+            },
+        );
+
+        let simulated_return_amount = RefCell::new(Uint128::zero());
+        suite.query_simulation(
+            "o.whale.uluna".to_string(),
+            Coin {
+                denom: "uwhale".to_string(),
+                amount: Uint128::from(1000u128),
+            },
+            "uluna".to_string(),
+            |result| {
+                let response = result.as_ref().unwrap();
+
+                // the protocol fee is 1% of the output amount
+                assert_approx_eq!(response.protocol_fee_amount, Uint128::new(10u128), "0.1");
+
+                // the swap fee is 2% of the output amount
+                assert_approx_eq!(response.swap_fee_amount, Uint128::new(20u128), "0.1");
+
+                // the burn fee is 3% of the output amount
+                assert_approx_eq!(response.burn_fee_amount, Uint128::new(30u128), "0.1");
+
+                // the extra fees are 4% of the output amount
+                assert_approx_eq!(response.extra_fees_amount, Uint128::new(40u128), "0.1");
+
+                *simulated_return_amount.borrow_mut() = response.return_amount;
+            },
+        );
+
+        // Now Let's try a swap
+        suite.swap(
+            &creator,
+            "uluna".to_string(),
+            None,
+            Some(Decimal::percent(10)),
+            None,
+            "o.whale.uluna".to_string(),
+            vec![coin(1000u128, "uwhale".to_string())],
+            |result| {
+                let mut return_amount = String::new();
+                for event in result.unwrap().events {
+                    if event.ty == "wasm" {
+                        for attribute in event.attributes {
+                            match attribute.key.as_str() {
+                                "return_amount" => return_amount = attribute.value,
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+
+                // return amount must be approximately equal to the value returned by the simulation
+                assert_approx_eq!(
+                    simulated_return_amount.borrow().u128(),
+                    return_amount.parse::<u128>().unwrap(),
+                    "0.00000001"
+                );
+            },
+        );
+    }
+
+    //todo remove when the stableswap issues are mitigated
+    /*
     #[test]
     fn simulation_queries_fees_verification() {
         let mut suite = TestingSuite::default_with_balances(
@@ -8601,8 +8790,366 @@ mod query_simulations {
             },
         );
     }
+    */
+
+    //todo remove when the stableswap issues are mitigated
+    /*#[test]
+    fn simulate_swap_operations_query_verification() {
+        let mut suite = TestingSuite::default_with_balances(
+            vec![
+                coin(1_000_000_000_001u128, "uom".to_string()),
+                coin(1_000_000_000_000u128, "uusdt".to_string()),
+                coin(1_000_000_000_001u128, "uusd".to_string()),
+                coin(1_000_000_000_001u128, "uusdc".to_string()),
+            ],
+            StargateMock::new(vec![coin(8888u128, "uom".to_string())]),
+        );
+        let creator = suite.creator();
+
+        let asset_infos = vec!["uom".to_string(), "uusdt".to_string()];
+
+        // protocol fee 1%
+        // swap fee 2%
+        // burn fee 3%
+        // extra fee 4%
+        let pool_fees = PoolFee {
+            protocol_fee: Fee {
+                share: Decimal::percent(1u64),
+            },
+            swap_fee: Fee {
+                share: Decimal::percent(2u64),
+            },
+            burn_fee: Fee {
+                share: Decimal::percent(3u64),
+            },
+            extra_fees: vec![Fee {
+                share: Decimal::percent(4u64),
+            }],
+        };
+
+        // Create a pool
+        suite
+            .instantiate_default()
+            .add_one_epoch()
+            .create_pool(
+                &creator,
+                asset_infos,
+                vec![6u8, 6u8],
+                pool_fees.clone(),
+                PoolType::ConstantProduct,
+                Some("uom.uusdt".to_string()),
+                vec![coin(1000, "uusd"), coin(8888, "uom")],
+                |result| {
+                    result.unwrap();
+                },
+            )
+            .create_pool(
+                &creator,
+                vec!["uusdt".to_string(), "uusdc".to_string()],
+                vec![6u8, 6u8],
+                pool_fees,
+                PoolType::StableSwap { amp: 85 },
+                Some("uusdt.uusdc".to_string()),
+                vec![coin(1000, "uusd"), coin(8888, "uom")],
+                |result| {
+                    result.unwrap();
+                },
+            );
+
+        // Let's try to add liquidity
+        suite
+            .provide_liquidity(
+                &creator,
+                "o.uom.uusdt".to_string(),
+                None,
+                None,
+                None,
+                None,
+                None,
+                vec![
+                    Coin {
+                        denom: "uom".to_string(),
+                        amount: Uint128::from(1_000_000_000u128),
+                    },
+                    Coin {
+                        denom: "uusdt".to_string(),
+                        amount: Uint128::from(4_000_000_000u128),
+                    },
+                ],
+                |result| {
+                    result.unwrap();
+                },
+            )
+            .provide_liquidity(
+                &creator,
+                "o.uusdt.uusdc".to_string(),
+                None,
+                None,
+                None,
+                None,
+                None,
+                vec![
+                    Coin {
+                        denom: "uusdt".to_string(),
+                        amount: Uint128::from(1_000_000_000u128),
+                    },
+                    Coin {
+                        denom: "uusdc".to_string(),
+                        amount: Uint128::from(1_000_000_000u128),
+                    },
+                ],
+                |result| {
+                    result.unwrap();
+                },
+            );
+
+        let simulated_return_amount = RefCell::new(Uint128::zero());
+        suite.query_simulate_swap_operations(
+            Uint128::from(1000u128),
+            vec![
+                SwapOperation::MantraSwap {
+                    token_in_denom: "uom".to_string(),
+                    token_out_denom: "uusdt".to_string(),
+                    pool_identifier: "o.uom.uusdt".to_string(),
+                },
+                SwapOperation::MantraSwap {
+                    token_in_denom: "uusdt".to_string(),
+                    token_out_denom: "uusdc".to_string(),
+                    pool_identifier: "o.uusdt.uusdc".to_string(),
+                },
+            ],
+            |result| {
+                println!("{:?}", result);
+                let response = result.unwrap();
+
+                assert_eq!(response.return_amount, Uint128::from(3243u128));
+                assert_eq!(
+                    response.spreads,
+                    vec![
+                        coin(360u128, "uusdc".to_string()),
+                        coin(397u128, "uusdt".to_string())
+                    ]
+                );
+                assert_eq!(
+                    response.swap_fees,
+                    vec![
+                        coin(72u128, "uusdc".to_string()),
+                        coin(79u128, "uusdt".to_string()),
+                    ]
+                );
+                assert_eq!(
+                    response.protocol_fees,
+                    vec![
+                        coin(36u128, "uusdc".to_string()),
+                        coin(39u128, "uusdt".to_string()),
+                    ]
+                );
+                assert_eq!(
+                    response.burn_fees,
+                    vec![
+                        coin(108u128, "uusdc".to_string()),
+                        coin(119u128, "uusdt".to_string()),
+                    ]
+                );
+                assert_eq!(
+                    response.extra_fees,
+                    vec![
+                        coin(144u128, "uusdc".to_string()),
+                        coin(159u128, "uusdt".to_string()),
+                    ]
+                );
+
+                simulated_return_amount
+                    .borrow_mut()
+                    .clone_from(&response.return_amount);
+            },
+        );
+
+        // Now Let's try a swap
+        suite.execute_swap_operations(
+            &creator,
+            vec![
+                SwapOperation::MantraSwap {
+                    token_in_denom: "uom".to_string(),
+                    token_out_denom: "uusdt".to_string(),
+                    pool_identifier: "o.uom.uusdt".to_string(),
+                },
+                SwapOperation::MantraSwap {
+                    token_in_denom: "uusdt".to_string(),
+                    token_out_denom: "uusdc".to_string(),
+                    pool_identifier: "o.uusdt.uusdc".to_string(),
+                },
+            ],
+            None,
+            None,
+            Some(Decimal::percent(10)),
+            vec![coin(1000u128, "uom".to_string())],
+            |result| {
+                println!("{:?}", result);
+                let mut return_amount = String::new();
+                for event in result.unwrap().events {
+                    if event.ty == "wasm" {
+                        for attribute in event.attributes {
+                            match attribute.key.as_str() {
+                                "return_amount" => return_amount = attribute.value,
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+
+                // return amount must be approximately equal to the value returned by the simulation
+                assert_approx_eq!(
+                    simulated_return_amount.borrow().u128(),
+                    return_amount.parse::<u128>().unwrap(),
+                    "0.00000001"
+                );
+            },
+        );
+    }*/
 
     #[test]
+    fn simulate_swap_operations_query_verification() {
+        let mut suite = TestingSuite::default_with_balances(
+            vec![
+                coin(1_000_000_000_001u128, "uom".to_string()),
+                coin(1_000_000_000_000u128, "uusdt".to_string()),
+                coin(1_000_000_000_001u128, "uusd".to_string()),
+                coin(1_000_000_000_001u128, "uusdc".to_string()),
+            ],
+            StargateMock::new(vec![coin(8888u128, "uom".to_string())]),
+        );
+        let creator = suite.creator();
+
+        let asset_infos = vec!["uom".to_string(), "uusdt".to_string()];
+
+        // protocol fee 1%
+        // swap fee 2%
+        // burn fee 3%
+        // extra fee 4%
+        let pool_fees = PoolFee {
+            protocol_fee: Fee {
+                share: Decimal::percent(1u64),
+            },
+            swap_fee: Fee {
+                share: Decimal::percent(2u64),
+            },
+            burn_fee: Fee {
+                share: Decimal::percent(3u64),
+            },
+            extra_fees: vec![Fee {
+                share: Decimal::percent(4u64),
+            }],
+        };
+
+        // Create a pool
+        suite.instantiate_default().add_one_epoch().create_pool(
+            &creator,
+            asset_infos,
+            vec![6u8, 6u8],
+            pool_fees.clone(),
+            PoolType::ConstantProduct,
+            Some("uom.uusdt".to_string()),
+            vec![coin(1000, "uusd"), coin(8888, "uom")],
+            |result| {
+                result.unwrap();
+            },
+        );
+
+        // Let's try to add liquidity
+        suite.provide_liquidity(
+            &creator,
+            "o.uom.uusdt".to_string(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            vec![
+                Coin {
+                    denom: "uom".to_string(),
+                    amount: Uint128::from(1_000_000_000u128),
+                },
+                Coin {
+                    denom: "uusdt".to_string(),
+                    amount: Uint128::from(4_000_000_000u128),
+                },
+            ],
+            |result| {
+                result.unwrap();
+            },
+        );
+
+        let simulated_return_amount = RefCell::new(Uint128::zero());
+        suite.query_simulate_swap_operations(
+            Uint128::from(1000u128),
+            vec![SwapOperation::MantraSwap {
+                token_in_denom: "uom".to_string(),
+                token_out_denom: "uusdt".to_string(),
+                pool_identifier: "o.uom.uusdt".to_string(),
+            }],
+            |result| {
+                let response = result.unwrap();
+
+                assert_eq!(response.return_amount, Uint128::from(3603u128));
+                assert_eq!(response.spreads, vec![coin(397u128, "uusdt".to_string())]);
+                assert_eq!(response.swap_fees, vec![coin(79u128, "uusdt".to_string()),]);
+                assert_eq!(
+                    response.protocol_fees,
+                    vec![coin(39u128, "uusdt".to_string()),]
+                );
+                assert_eq!(
+                    response.burn_fees,
+                    vec![coin(119u128, "uusdt".to_string()),]
+                );
+                assert_eq!(
+                    response.extra_fees,
+                    vec![coin(159u128, "uusdt".to_string()),]
+                );
+
+                simulated_return_amount
+                    .borrow_mut()
+                    .clone_from(&response.return_amount);
+            },
+        );
+
+        // Now Let's try a swap
+        suite.execute_swap_operations(
+            &creator,
+            vec![SwapOperation::MantraSwap {
+                token_in_denom: "uom".to_string(),
+                token_out_denom: "uusdt".to_string(),
+                pool_identifier: "o.uom.uusdt".to_string(),
+            }],
+            None,
+            None,
+            Some(Decimal::percent(10)),
+            vec![coin(1000u128, "uom".to_string())],
+            |result| {
+                let mut return_amount = String::new();
+                for event in result.unwrap().events {
+                    if event.ty == "wasm" {
+                        for attribute in event.attributes {
+                            match attribute.key.as_str() {
+                                "return_amount" => return_amount = attribute.value,
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+
+                // return amount must be approximately equal to the value returned by the simulation
+                assert_approx_eq!(
+                    simulated_return_amount.borrow().u128(),
+                    return_amount.parse::<u128>().unwrap(),
+                    "0.00000001"
+                );
+            },
+        );
+    }
+
+    //todo remove when the stableswap issues are mitigated
+    /*#[test]
     fn reverse_simulation_queries_fees_verification() {
         let mut suite = TestingSuite::default_with_balances(
             vec![
@@ -8842,22 +9389,23 @@ mod query_simulations {
                 assert_approx_eq!(900u128, return_amount.parse::<u128>().unwrap(), "0.002");
             },
         );
-    }
+    }*/
 
     #[test]
-    fn simulate_swap_operations_query_verification() {
+    fn reverse_simulation_queries_fees_verification() {
         let mut suite = TestingSuite::default_with_balances(
             vec![
-                coin(1_000_000_000_001u128, "uom".to_string()),
-                coin(1_000_000_000_000u128, "uusdt".to_string()),
+                coin(1_000_000_000_001u128, "uwhale".to_string()),
+                coin(1_000_000_000_000u128, "uluna".to_string()),
                 coin(1_000_000_000_001u128, "uusd".to_string()),
                 coin(1_000_000_000_001u128, "uusdc".to_string()),
+                coin(1_000_000_000_001u128, "uom".to_string()),
             ],
             StargateMock::new(vec![coin(8888u128, "uom".to_string())]),
         );
         let creator = suite.creator();
 
-        let asset_infos = vec!["uom".to_string(), "uusdt".to_string()];
+        let asset_infos = vec!["uwhale".to_string(), "uluna".to_string()];
 
         // protocol fee 1%
         // swap fee 2%
@@ -8879,187 +9427,110 @@ mod query_simulations {
         };
 
         // Create a pool
-        suite
-            .instantiate_default()
-            .add_one_epoch()
-            .create_pool(
-                &creator,
-                asset_infos,
-                vec![6u8, 6u8],
-                pool_fees.clone(),
-                PoolType::ConstantProduct,
-                Some("uom.uusdt".to_string()),
-                vec![coin(1000, "uusd"), coin(8888, "uom")],
-                |result| {
-                    result.unwrap();
-                },
-            )
-            .create_pool(
-                &creator,
-                vec!["uusdt".to_string(), "uusdc".to_string()],
-                vec![6u8, 6u8],
-                pool_fees,
-                PoolType::StableSwap { amp: 85 },
-                Some("uusdt.uusdc".to_string()),
-                vec![coin(1000, "uusd"), coin(8888, "uom")],
-                |result| {
-                    result.unwrap();
-                },
-            );
-
-        // Let's try to add liquidity
-        suite
-            .provide_liquidity(
-                &creator,
-                "o.uom.uusdt".to_string(),
-                None,
-                None,
-                None,
-                None,
-                None,
-                vec![
-                    Coin {
-                        denom: "uom".to_string(),
-                        amount: Uint128::from(1_000_000_000u128),
-                    },
-                    Coin {
-                        denom: "uusdt".to_string(),
-                        amount: Uint128::from(4_000_000_000u128),
-                    },
-                ],
-                |result| {
-                    result.unwrap();
-                },
-            )
-            .provide_liquidity(
-                &creator,
-                "o.uusdt.uusdc".to_string(),
-                None,
-                None,
-                None,
-                None,
-                None,
-                vec![
-                    Coin {
-                        denom: "uusdt".to_string(),
-                        amount: Uint128::from(1_000_000_000u128),
-                    },
-                    Coin {
-                        denom: "uusdc".to_string(),
-                        amount: Uint128::from(1_000_000_000u128),
-                    },
-                ],
-                |result| {
-                    result.unwrap();
-                },
-            );
-
-        let simulated_return_amount = RefCell::new(Uint128::zero());
-        suite.query_simulate_swap_operations(
-            Uint128::from(1000u128),
-            vec![
-                SwapOperation::MantraSwap {
-                    token_in_denom: "uom".to_string(),
-                    token_out_denom: "uusdt".to_string(),
-                    pool_identifier: "o.uom.uusdt".to_string(),
-                },
-                SwapOperation::MantraSwap {
-                    token_in_denom: "uusdt".to_string(),
-                    token_out_denom: "uusdc".to_string(),
-                    pool_identifier: "o.uusdt.uusdc".to_string(),
-                },
-            ],
+        suite.instantiate_default().add_one_epoch().create_pool(
+            &creator,
+            asset_infos,
+            vec![6u8, 6u8],
+            pool_fees.clone(),
+            PoolType::ConstantProduct,
+            Some("whale.uluna".to_string()),
+            vec![coin(1000, "uusd"), coin(8888, "uom")],
             |result| {
-                println!("{:?}", result);
-                let response = result.unwrap();
-
-                assert_eq!(response.return_amount, Uint128::from(3243u128));
-                assert_eq!(
-                    response.spreads,
-                    vec![
-                        coin(360u128, "uusdc".to_string()),
-                        coin(397u128, "uusdt".to_string())
-                    ]
-                );
-                assert_eq!(
-                    response.swap_fees,
-                    vec![
-                        coin(72u128, "uusdc".to_string()),
-                        coin(79u128, "uusdt".to_string()),
-                    ]
-                );
-                assert_eq!(
-                    response.protocol_fees,
-                    vec![
-                        coin(36u128, "uusdc".to_string()),
-                        coin(39u128, "uusdt".to_string()),
-                    ]
-                );
-                assert_eq!(
-                    response.burn_fees,
-                    vec![
-                        coin(108u128, "uusdc".to_string()),
-                        coin(119u128, "uusdt".to_string()),
-                    ]
-                );
-                assert_eq!(
-                    response.extra_fees,
-                    vec![
-                        coin(144u128, "uusdc".to_string()),
-                        coin(159u128, "uusdt".to_string()),
-                    ]
-                );
-
-                simulated_return_amount
-                    .borrow_mut()
-                    .clone_from(&response.return_amount);
+                result.unwrap();
             },
         );
 
-        // Now Let's try a swap
-        suite.execute_swap_operations(
+        // Let's try to add liquidity
+        suite.provide_liquidity(
             &creator,
+            "o.whale.uluna".to_string(),
+            None,
+            None,
+            None,
+            None,
+            None,
             vec![
-                SwapOperation::MantraSwap {
-                    token_in_denom: "uom".to_string(),
-                    token_out_denom: "uusdt".to_string(),
-                    pool_identifier: "o.uom.uusdt".to_string(),
+                Coin {
+                    denom: "uwhale".to_string(),
+                    amount: Uint128::from(1000000000u128),
                 },
-                SwapOperation::MantraSwap {
-                    token_in_denom: "uusdt".to_string(),
-                    token_out_denom: "uusdc".to_string(),
-                    pool_identifier: "o.uusdt.uusdc".to_string(),
+                Coin {
+                    denom: "uluna".to_string(),
+                    amount: Uint128::from(1000000000u128),
                 },
             ],
-            None,
-            None,
-            Some(Decimal::percent(10)),
-            vec![coin(1000u128, "uom".to_string())],
             |result| {
-                println!("{:?}", result);
+                result.unwrap();
+            },
+        );
+
+        let simulated_offer_amount = RefCell::new(Uint128::zero());
+        suite.query_reverse_simulation(
+            "o.whale.uluna".to_string(),
+            Coin {
+                denom: "uwhale".to_string(),
+                // reuse the value of the previous test
+                amount: Uint128::from(903u128),
+            },
+            "uluna".to_string(),
+            |result| {
+                let response = result.as_ref().unwrap();
+
+                // the fees should be the same as the previous test, as we requested
+                // the reverse simulation for the value we obtained before
+
+                assert_approx_eq!(response.protocol_fee_amount, Uint128::new(10u128), "0.1");
+
+                assert_approx_eq!(response.swap_fee_amount, Uint128::new(20u128), "0.1");
+
+                assert_approx_eq!(response.burn_fee_amount, Uint128::new(30u128), "0.1");
+
+                assert_approx_eq!(response.extra_fees_amount, Uint128::new(40u128), "0.1");
+
+                *simulated_offer_amount.borrow_mut() = response.offer_amount;
+            },
+        );
+
+        // Another swap but this time the other way around
+        suite.swap(
+            &creator,
+            "uwhale".to_string(),
+            None,
+            Some(Decimal::percent(11)),
+            None,
+            "o.whale.uluna".to_string(),
+            vec![coin(
+                simulated_offer_amount.borrow().u128(),
+                "uluna".to_string(),
+            )],
+            |result| {
                 let mut return_amount = String::new();
+                let mut offer_amount = String::new();
+
                 for event in result.unwrap().events {
                     if event.ty == "wasm" {
                         for attribute in event.attributes {
                             match attribute.key.as_str() {
                                 "return_amount" => return_amount = attribute.value,
+                                "offer_amount" => offer_amount = attribute.value,
                                 _ => {}
                             }
                         }
                     }
                 }
-
-                // return amount must be approximately equal to the value returned by the simulation
                 assert_approx_eq!(
-                    simulated_return_amount.borrow().u128(),
-                    return_amount.parse::<u128>().unwrap(),
-                    "0.00000001"
+                    simulated_offer_amount.borrow().u128(),
+                    offer_amount.parse::<u128>().unwrap(),
+                    "0.002"
                 );
+
+                assert_approx_eq!(903u128, return_amount.parse::<u128>().unwrap(), "0.002");
             },
         );
     }
 
-    #[test]
+    //todo remove when the stableswap issues are mitigated
+    /*#[test]
     fn reverse_simulate_swap_operations_query_verification() {
         let mut suite = TestingSuite::default_with_balances(
             vec![
@@ -9247,6 +9718,151 @@ mod query_simulations {
                     pool_identifier: "o.uusdt.uusdc".to_string(),
                 },
             ],
+            None,
+            None,
+            Some(Decimal::percent(10)),
+            vec![coin(
+                simulated_input_amount.borrow().u128(),
+                "uom".to_string(),
+            )],
+            |result| {
+                let mut return_amount = String::new();
+                for event in result.unwrap().events {
+                    if event.ty == "wasm" {
+                        for attribute in event.attributes {
+                            match attribute.key.as_str() {
+                                "return_amount" => return_amount = attribute.value,
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+
+                // return amount must be approximately equal (a bit higher) to the value returned by the simulation
+                assert_approx_eq!(
+                    desired_output_amount.u128(),
+                    return_amount.parse::<u128>().unwrap(),
+                    "0.001"
+                );
+            },
+        );
+    }*/
+
+    #[test]
+    fn reverse_simulate_swap_operations_query_verification() {
+        let mut suite = TestingSuite::default_with_balances(
+            vec![
+                coin(1_000_000_000_001u128, "uom".to_string()),
+                coin(1_000_000_000_000u128, "uusdt".to_string()),
+                coin(1_000_000_000_001u128, "uusd".to_string()),
+                coin(1_000_000_000_001u128, "uusdc".to_string()),
+            ],
+            StargateMock::new(vec![coin(8888u128, "uom".to_string())]),
+        );
+        let creator = suite.creator();
+
+        let asset_infos = vec!["uom".to_string(), "uusdt".to_string()];
+
+        // protocol fee 1%
+        // swap fee 2%
+        // burn fee 3%
+        // extra fee 4%
+        let pool_fees = PoolFee {
+            protocol_fee: Fee {
+                share: Decimal::percent(1u64),
+            },
+            swap_fee: Fee {
+                share: Decimal::percent(2u64),
+            },
+            burn_fee: Fee {
+                share: Decimal::percent(3u64),
+            },
+            extra_fees: vec![Fee {
+                share: Decimal::percent(4u64),
+            }],
+        };
+
+        // Create a pool
+        suite.instantiate_default().add_one_epoch().create_pool(
+            &creator,
+            asset_infos,
+            vec![6u8, 6u8],
+            pool_fees.clone(),
+            PoolType::ConstantProduct,
+            Some("uom.uusdt".to_string()),
+            vec![coin(1000, "uusd"), coin(8888, "uom")],
+            |result| {
+                result.unwrap();
+            },
+        );
+
+        // Let's try to add liquidity
+        suite.provide_liquidity(
+            &creator,
+            "o.uom.uusdt".to_string(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            vec![
+                Coin {
+                    denom: "uom".to_string(),
+                    amount: Uint128::from(1000000000u128),
+                },
+                Coin {
+                    denom: "uusdt".to_string(),
+                    amount: Uint128::from(4000000000u128),
+                },
+            ],
+            |result| {
+                result.unwrap();
+            },
+        );
+
+        let simulated_input_amount = RefCell::new(Uint128::zero());
+        let desired_output_amount = Uint128::from(3240u128);
+        suite.query_reverse_simulate_swap_operations(
+            desired_output_amount,
+            vec![SwapOperation::MantraSwap {
+                token_in_denom: "uom".to_string(),
+                token_out_denom: "uusdt".to_string(),
+                pool_identifier: "o.uom.uusdt".to_string(),
+            }],
+            |result| {
+                let response = result.unwrap();
+
+                // this is the value we got in the previous test for the regular simulation
+                assert_approx_eq!(response.offer_amount, Uint128::from(900u128), "0.001");
+                assert_eq!(response.spreads, vec![coin(1u128, "uusdt".to_string()),]);
+                assert_eq!(response.swap_fees, vec![coin(71u128, "uusdt".to_string()),]);
+                assert_eq!(
+                    response.protocol_fees,
+                    vec![coin(35u128, "uusdt".to_string()),]
+                );
+                assert_eq!(
+                    response.burn_fees,
+                    vec![coin(107u128, "uusdt".to_string()),]
+                );
+                assert_eq!(
+                    response.extra_fees,
+                    vec![coin(143u128, "uusdt".to_string()),]
+                );
+
+                simulated_input_amount
+                    .borrow_mut()
+                    .clone_from(&response.offer_amount);
+            },
+        );
+
+        // Now Let's try a swap
+        suite.execute_swap_operations(
+            &creator,
+            vec![SwapOperation::MantraSwap {
+                token_in_denom: "uom".to_string(),
+                token_out_denom: "uusdt".to_string(),
+                pool_identifier: "o.uom.uusdt".to_string(),
+            }],
             None,
             None,
             Some(Decimal::percent(10)),


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

This PR temporarily disables the creation of stableswap pools while some issues are fixed.

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/MANTRA-Finance/amm/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to MANTRA!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Chain/mantra-dex/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `just fmt`.
- [x] Clippy doesn't report any issues `just lint`.
- [x] I have regenerated the schemas if needed with `just schemas`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced pool creation by enforcing supported pool types, ensuring users receive a clear error message when attempting unsupported configurations.
  - Improved swap simulation functionality with precise fee breakdowns and more robust liquidity provision handling.

- **Tests**
  - Introduced new tests to verify that unsupported pool types are rejected and to confirm the accuracy of fee calculations and liquidity validations across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->