### PR TITLE
ci: bump maximumSize wasm file on script

### DIFF
--- a/scripts/check_artifacts_size.sh
+++ b/scripts/check_artifacts_size.sh
@@ -4,7 +4,7 @@ set -e
 # Maximum wasm file size
 if [[ -z $1 ]]; then
 	# Default max file size
-	maximumSize=600
+	maximumSize=2500
 else
 	maximumSize=$1
 fi


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

This bumps the maximum default size of the wasm files (to the new limit on chain) in the `check_artifacts_size` script, as it was breaking a ci action.

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/MANTRA-Finance/amm/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to MANTRA!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Chain/mantra-dex/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `just fmt`.
- [x] Clippy doesn't report any issues `just lint`.
- [x] I have regenerated the schemas if needed with `just schemas`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Increased the default file size threshold for WebAssembly files from 600 kB to 2500 kB. This update accommodates larger file sizes, ensuring a smoother deployment and reducing potential false alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->