### PR TITLE
chore(pool_manager): remove duplicated attribute on response

### DIFF
--- a/contracts/pool-manager/src/liquidity/commands.rs
+++ b/contracts/pool-manager/src/liquidity/commands.rs
@@ -419,14 +419,6 @@ pub fn provide_liquidity(
             ("action", "provide_liquidity"),
             ("sender", info.sender.as_str()),
             ("receiver", receiver.as_str()),
-            (
-                "assets",
-                &pool_assets
-                    .iter()
-                    .map(|asset| asset.to_string())
-                    .collect::<Vec<_>>()
-                    .join(", "),
-            ),
             ("added_shares", &shares.to_string()),
             ("pool_identifier", &pool_identifier),
             ("pool_reserves", &pool_reserves),


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

This PR removes the duplicated attribute `assets` when providing liquidity in a pool.

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/MANTRA-Finance/amm/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to MANTRA!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Chain/mantra-dex/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `just fmt`.
- [x] Clippy doesn't report any issues `just lint`.
- [x] I have regenerated the schemas if needed with `just schemas`.
