### PR TITLE
fix: prevent setting genesis_epoch to past times

### DIFF
--- a/contracts/epoch-manager/src/contract.rs
+++ b/contracts/epoch-manager/src/contract.rs
@@ -57,7 +57,7 @@ pub fn execute(
     match msg {
         ExecuteMsg::UpdateConfig { epoch_config } => {
             cw_utils::nonpayable(&info)?;
-            commands::update_config(deps, &info, epoch_config)
+            commands::update_config(deps, env, &info, epoch_config)
         }
         ExecuteMsg::UpdateOwnership(action) => {
             cw_utils::nonpayable(&info)?;


### PR DESCRIPTION
- Added validation to ensure genesis_epoch can only be updated to future timestamps
- Updated function signature to include environment for timestamp validation
- Added appropriate error handling via InvalidStartTime error
- Updated tests to use future timestamps and added test for past timestamp rejection

## Description and Motivation

fixes: https://github.com/MANTRA-Chain/mantra-dex/issues/167
## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/MANTRA-Finance/amm/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to MANTRA!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->


Here's the checklist with all boxes checked:

- [x] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Chain/mantra-dex/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `just fmt`.
- [x] Clippy doesn't report any issues `just lint`.
- [x] I have regenerated the schemas if needed with `just schemas`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the configuration update process to ensure that any provided start time is in the future. Attempts to update with a past time will now be blocked, ensuring a more robust configuration update experience.
	- Introduced a new test to validate behavior when attempting to set a `genesis_epoch` in the past, ensuring proper error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->