### PR TITLE
Fix stableswap overflow for large token amounts

### DIFF
--- a/contracts/pool-manager/src/helpers.rs
+++ b/contracts/pool-manager/src/helpers.rs
@@ -152,11 +152,9 @@ pub fn calculate_stableswap_y(
 
         if y >= previous_y {
             if y.checked_sub(previous_y)? <= Uint512::one() {
-                println!("y: {}", y);
                 return y.try_into().map_err(|_| ContractError::SwapOverflowError);
             }
         } else if y < previous_y && previous_y.checked_sub(y)? <= Uint512::one() {
-            println!("y: {}", y);
             return y.try_into().map_err(|_| ContractError::SwapOverflowError);
         }
     }

--- a/contracts/pool-manager/src/queries.rs
+++ b/contracts/pool-manager/src/queries.rs
@@ -174,12 +174,9 @@ pub fn query_reverse_simulation(
                     extra_fees_amount.checked_add(extra_fee.compute(before_fees_ask)?)?;
             }
 
-            let offer_amount = offer_amount.try_into()?;
-            let spread_amount = spread_amount.try_into()?;
-
             Ok(ReverseSimulationResponse {
-                offer_amount,
-                spread_amount,
+                offer_amount: offer_amount.try_into()?,
+                spread_amount: spread_amount.try_into()?,
                 swap_fee_amount: swap_fee_amount.try_into()?,
                 protocol_fee_amount: protocol_fee_amount.try_into()?,
                 burn_fee_amount: burn_fee_amount.try_into()?,

--- a/contracts/pool-manager/src/queries.rs
+++ b/contracts/pool-manager/src/queries.rs
@@ -149,23 +149,21 @@ pub fn query_reverse_simulation(
                 StableSwapDirection::ReverseSimulate,
             )?;
 
-            let offer_amount = new_offer_pool_amount.checked_sub(Uint128::try_from(
-                offer_pool.to_uint256_with_precision(u32::from(max_precision))?,
-            )?)?;
+            let offer_amount = new_offer_pool_amount
+                .checked_sub(offer_pool.to_uint256_with_precision(u32::from(max_precision))?)?;
 
             // convert into the original offer precision
             let offer_amount = match max_precision.cmp(&offer_decimal) {
                 Ordering::Equal => offer_amount,
                 // note that Less should never happen (as max_precision = max(offer_decimal, ask_decimal))
-                Ordering::Less => offer_amount.checked_mul(Uint128::new(
+                Ordering::Less => offer_amount.checked_mul(Uint256::from(
                     10u128.pow((offer_decimal - max_precision).into()),
                 ))?,
-                Ordering::Greater => offer_amount.checked_div(Uint128::new(
+                Ordering::Greater => offer_amount.checked_div(Uint256::from(
                     10u128.pow((max_precision - offer_decimal).into()),
                 ))?,
             };
-
-            let spread_amount = offer_amount.saturating_sub(Uint128::try_from(before_fees_offer)?);
+            let spread_amount = offer_amount.saturating_sub(before_fees_offer);
             let swap_fee_amount = pool_fees.swap_fee.compute(before_fees_ask)?;
             let protocol_fee_amount = pool_fees.protocol_fee.compute(before_fees_ask)?;
             let burn_fee_amount = pool_fees.burn_fee.compute(before_fees_ask)?;
@@ -175,6 +173,9 @@ pub fn query_reverse_simulation(
                 extra_fees_amount =
                     extra_fees_amount.checked_add(extra_fee.compute(before_fees_ask)?)?;
             }
+
+            let offer_amount = offer_amount.try_into()?;
+            let spread_amount = spread_amount.try_into()?;
 
             Ok(ReverseSimulationResponse {
                 offer_amount,


### PR DESCRIPTION

# Fix stableswap overflow for large token amounts

## Description and Motivation

This PR addresses a critical overflow issue in the stableswap implementation when handling large token amounts, particularly for tokens with high decimal places (18). The main changes include:

1. Updated `calculate_stableswap_y` function to return `Uint256` instead of `Uint128`
2. Replaced intermediate calculations to use `Uint512` instead of `Uint256` to prevent overflow
3. Added a test case demonstrating the function now handles large amounts (1M tokens with 18 decimals)
4. Updated related functions in queries.rs to handle the new return types

These changes ensure stable swaps work correctly with tokens that have large supplies and high decimal precision.

## Related Issues

Fixes https://github.com/MANTRA-Chain/mantra-dex/issues/171

---

## Checklist:

- [x] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Chain/mantra-dex/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation.
- [x] The code is formatted properly `just fmt`.
- [x] Clippy doesn't report any issues `just lint`.
- [x] I have regenerated the schemas if needed with `just schemas`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced numerical precision in swap and simulation calculations to reliably handle large transaction amounts and prevent potential overflow errors.
  
- **Tests**
  - Added targeted tests to verify robust behavior when processing large token values, ensuring accurate and consistent results during swap operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->