### PR TITLE
chore: bump farm-manager and epoch-manager versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "epoch-manager"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "farm-manager"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",

--- a/contracts/epoch-manager/Cargo.toml
+++ b/contracts/epoch-manager/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace       = true
 name                    = "epoch-manager"
 publish.workspace       = true
 repository.workspace    = true
-version                 = "1.0.0"
+version                 = "1.1.0"
 
 exclude = [
   # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.

--- a/contracts/farm-manager/Cargo.toml
+++ b/contracts/farm-manager/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace       = true
 name                    = "farm-manager"
 publish.workspace       = true
 repository.workspace    = true
-version                 = "1.0.0"
+version                 = "1.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/MANTRA-Chain/mantra-dex/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to MANTRA!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [ ] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Chain/mantra-dex/blob/main/docs/CONTRIBUTING.md).
- [ ] My pull request has a sound title and description (not something vague like `Update index.md`)
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation.
- [ ] The code is formatted properly `just fmt`.
- [ ] Clippy doesn't report any issues `just lint`.
- [ ] I have regenerated the schemas if needed with `just schemas`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated version numbers for the epoch-manager and farm-manager packages to 1.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->